### PR TITLE
Extract root columns from BigQuery schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jsonschema-transpiler"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonschema-transpiler"
-version = "0.5.0"
+version = "1.0.0"
 authors = ["Anthony Miyaguchi <amiyaguchi@mozilla.com>"]
 description = "A tool to transpile JSON Schema into schemas for data processing"
 license = "MPL-2.0"

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -1,6 +1,8 @@
 use super::ast;
 use std::collections::HashMap;
 
+const DEFAULT_COLUMN: &str = "root";
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE", tag = "type")]
 pub enum Atom {
@@ -130,12 +132,12 @@ impl From<ast::Tag> for Schema {
         match *bq_tag.data_type {
             Type::Record(_) if tag.is_array() || tag.is_map() => {
                 assert!(bq_tag.name.is_none());
-                bq_tag.name = Some("root".into());
+                bq_tag.name = Some(DEFAULT_COLUMN.into());
                 Schema::Root(vec![bq_tag])
             }
             Type::Atom(_) => {
                 assert!(bq_tag.name.is_none());
-                bq_tag.name = Some("root".into());
+                bq_tag.name = Some(DEFAULT_COLUMN.into());
                 Schema::Root(vec![bq_tag])
             }
             Type::Record(record) => {

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -1,6 +1,4 @@
 use super::ast;
-use serde::de::{self, Deserialize, Deserializer};
-use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -28,7 +26,7 @@ pub enum Mode {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(tag="type", rename = "RECORD")]
+#[serde(tag = "type", rename = "RECORD")]
 pub struct Record {
     #[serde(with = "fields_as_vec")]
     fields: HashMap<String, Box<Tag>>,
@@ -41,7 +39,6 @@ pub enum Type {
     Record(Record),
     Root(Vec<Tag>),
 }
-
 
 /// See: https://cloud.google.com/bigquery/docs/schemas#standard_sql_data_types
 #[derive(Serialize, Deserialize, Debug)]
@@ -84,7 +81,9 @@ impl From<ast::Tag> for Tag {
                 Type::Atom(Atom::String)
             }
             ast::Type::Object(object) if tag.is_root => {
-                let mut vec: Vec<_> = object.fields.iter()
+                let mut vec: Vec<_> = object
+                    .fields
+                    .iter()
                     .map(|(k, v)| (k.to_string(), Tag::from(*v.clone())))
                     .collect();
                 vec.sort_by_key(|(k, _)| k.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,6 @@ pub fn convert_avro(input: &Value) -> Value {
 
 /// Convert JSON Schema into a BigQuery compatible schema
 pub fn convert_bigquery(input: &Value) -> Value {
-    let bq = bigquery::Tag::from(into_ast(input));
+    let bq = bigquery::Schema::from(into_ast(input));
     json!(bq)
 }

--- a/tests/resources/array.json
+++ b/tests/resources/array.json
@@ -10,10 +10,13 @@
           },
           "type": "array"
         },
-        "bigquery": {
-          "mode": "REPEATED",
-          "type": "INT64"
-        },
+        "bigquery": [
+          {
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "INT64"
+          }
+        ],
         "json": {
           "items": {
             "type": "integer"
@@ -59,22 +62,25 @@
           },
           "type": "array"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_1",
-              "type": "STRING"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "INT64"
-            }
-          ],
-          "mode": "REPEATED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "field_1",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "field_2",
+                "type": "INT64"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "items": {
             "properties": {

--- a/tests/resources/atomic.json
+++ b/tests/resources/atomic.json
@@ -106,10 +106,13 @@
         "avro": {
           "type": "string"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "TIMESTAMP"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "TIMESTAMP"
+          }
+        ],
         "json": {
           "format": "date-time",
           "type": "string"

--- a/tests/resources/atomic.json
+++ b/tests/resources/atomic.json
@@ -7,10 +7,13 @@
         "avro": {
           "type": "long"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "INT64"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "INT64"
+          }
+        ],
         "json": {
           "type": "integer"
         }
@@ -27,10 +30,13 @@
             "type": "long"
           }
         ],
-        "bigquery": {
-          "mode": "NULLABLE",
-          "type": "INT64"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "root",
+            "type": "INT64"
+          }
+        ],
         "json": {
           "type": [
             "integer",
@@ -48,10 +54,13 @@
         "avro": {
           "type": "string"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "STRING"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
         "json": {
           "type": [
             "boolean",
@@ -75,10 +84,13 @@
             "type": "string"
           }
         ],
-        "bigquery": {
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
         "json": {
           "type": [
             "boolean",

--- a/tests/resources/map.json
+++ b/tests/resources/map.json
@@ -17,22 +17,25 @@
             "type": "long"
           }
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "REQUIRED",
-              "name": "key",
-              "type": "STRING"
-            },
-            {
-              "mode": "REQUIRED",
-              "name": "value",
-              "type": "INT64"
-            }
-          ],
-          "mode": "REPEATED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "key",
+                "type": "STRING"
+              },
+              {
+                "mode": "REQUIRED",
+                "name": "value",
+                "type": "INT64"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "additionalProperties": {
             "type": "integer"
@@ -78,34 +81,37 @@
             "type": "record"
           }
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "REQUIRED",
-              "name": "key",
-              "type": "STRING"
-            },
-            {
-              "fields": [
-                {
-                  "mode": "NULLABLE",
-                  "name": "field_1",
-                  "type": "STRING"
-                },
-                {
-                  "mode": "NULLABLE",
-                  "name": "field_2",
-                  "type": "INT64"
-                }
-              ],
-              "mode": "REQUIRED",
-              "name": "value",
-              "type": "RECORD"
-            }
-          ],
-          "mode": "REPEATED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "key",
+                "type": "STRING"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "field_1",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "field_2",
+                    "type": "INT64"
+                  }
+                ],
+                "mode": "REQUIRED",
+                "name": "value",
+                "type": "RECORD"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "additionalProperties": {
             "properties": {
@@ -131,22 +137,25 @@
             "type": "long"
           }
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "REQUIRED",
-              "name": "key",
-              "type": "STRING"
-            },
-            {
-              "mode": "REQUIRED",
-              "name": "value",
-              "type": "INT64"
-            }
-          ],
-          "mode": "REPEATED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "key",
+                "type": "STRING"
+              },
+              {
+                "mode": "REQUIRED",
+                "name": "value",
+                "type": "INT64"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "additionalProperties": false,
           "patternProperties": {
@@ -167,22 +176,25 @@
             "type": "long"
           }
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "REQUIRED",
-              "name": "key",
-              "type": "STRING"
-            },
-            {
-              "mode": "REQUIRED",
-              "name": "value",
-              "type": "INT64"
-            }
-          ],
-          "mode": "REPEATED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "key",
+                "type": "STRING"
+              },
+              {
+                "mode": "REQUIRED",
+                "name": "value",
+                "type": "INT64"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "additionalProperties": {
             "type": "integer"
@@ -205,22 +217,25 @@
             "type": "string"
           }
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "REQUIRED",
-              "name": "key",
-              "type": "STRING"
-            },
-            {
-              "mode": "REQUIRED",
-              "name": "value",
-              "type": "STRING"
-            }
-          ],
-          "mode": "REPEATED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "key",
+                "type": "STRING"
+              },
+              {
+                "mode": "REQUIRED",
+                "name": "value",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "additionalProperties": false,
           "patternProperties": {
@@ -244,22 +259,25 @@
             "type": "string"
           }
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "REQUIRED",
-              "name": "key",
-              "type": "STRING"
-            },
-            {
-              "mode": "REQUIRED",
-              "name": "value",
-              "type": "STRING"
-            }
-          ],
-          "mode": "REPEATED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "key",
+                "type": "STRING"
+              },
+              {
+                "mode": "REQUIRED",
+                "name": "value",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "additionalProperties": {
             "type": "integer"

--- a/tests/resources/object.json
+++ b/tests/resources/object.json
@@ -62,32 +62,28 @@
           "name": "root",
           "type": "record"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_1",
-              "type": "INT64"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "STRING"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_3",
-              "type": "BOOL"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_4",
-              "type": "FLOAT64"
-            }
-          ],
-          "mode": "REQUIRED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "field_1",
+            "type": "INT64"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_2",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_3",
+            "type": "BOOL"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_4",
+            "type": "FLOAT64"
+          }
+        ],
         "json": {
           "properties": {
             "field_1": {
@@ -144,27 +140,23 @@
           "name": "root",
           "type": "record"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "REQUIRED",
-              "name": "field_1",
-              "type": "INT64"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "STRING"
-            },
-            {
-              "mode": "REQUIRED",
-              "name": "field_3",
-              "type": "BOOL"
-            }
-          ],
-          "mode": "REQUIRED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "field_1",
+            "type": "INT64"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_2",
+            "type": "STRING"
+          },
+          {
+            "mode": "REQUIRED",
+            "name": "field_3",
+            "type": "BOOL"
+          }
+        ],
         "json": {
           "properties": {
             "field_1": {
@@ -229,27 +221,23 @@
           "name": "root",
           "type": "record"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_1",
-              "type": "INT64"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "STRING"
-            },
-            {
-              "mode": "REQUIRED",
-              "name": "field_3",
-              "type": "BOOL"
-            }
-          ],
-          "mode": "REQUIRED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "field_1",
+            "type": "INT64"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_2",
+            "type": "STRING"
+          },
+          {
+            "mode": "REQUIRED",
+            "name": "field_3",
+            "type": "BOOL"
+          }
+        ],
         "json": {
           "properties": {
             "field_1": {
@@ -322,29 +310,25 @@
           "name": "root",
           "type": "record"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "fields": [
-                {
-                  "mode": "NULLABLE",
-                  "name": "field_1",
-                  "type": "STRING"
-                },
-                {
-                  "mode": "NULLABLE",
-                  "name": "field_2",
-                  "type": "INT64"
-                }
-              ],
-              "mode": "NULLABLE",
-              "name": "namespace_1",
-              "type": "RECORD"
-            }
-          ],
-          "mode": "REQUIRED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "field_1",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "field_2",
+                "type": "INT64"
+              }
+            ],
+            "mode": "NULLABLE",
+            "name": "namespace_1",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "properties": {
             "namespace_1": {

--- a/tests/resources/object.json
+++ b/tests/resources/object.json
@@ -357,10 +357,13 @@
         "avro": {
           "type": "string"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "STRING"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
         "json": {
           "properties": {},
           "type": "object"

--- a/tests/resources/oneof.json
+++ b/tests/resources/oneof.json
@@ -139,22 +139,18 @@
           "name": "root",
           "type": "record"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_1",
-              "type": "INT64"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "INT64"
-            }
-          ],
-          "mode": "REQUIRED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "field_1",
+            "type": "INT64"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_2",
+            "type": "INT64"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -231,27 +227,23 @@
           "name": "root",
           "type": "record"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_1",
-              "type": "INT64"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "BOOL"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_3",
-              "type": "FLOAT64"
-            }
-          ],
-          "mode": "REQUIRED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "field_1",
+            "type": "INT64"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_2",
+            "type": "BOOL"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_3",
+            "type": "FLOAT64"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -365,44 +357,40 @@
           "name": "root",
           "type": "record"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_4",
-              "type": "BOOL"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_5",
-              "type": "FLOAT64"
-            },
-            {
-              "fields": [
-                {
-                  "mode": "NULLABLE",
-                  "name": "field_1",
-                  "type": "INT64"
-                },
-                {
-                  "mode": "NULLABLE",
-                  "name": "field_2",
-                  "type": "BOOL"
-                },
-                {
-                  "mode": "NULLABLE",
-                  "name": "field_3",
-                  "type": "FLOAT64"
-                }
-              ],
-              "mode": "NULLABLE",
-              "name": "namespace_1",
-              "type": "RECORD"
-            }
-          ],
-          "mode": "REQUIRED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "field_4",
+            "type": "BOOL"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_5",
+            "type": "FLOAT64"
+          },
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "field_1",
+                "type": "INT64"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "field_2",
+                "type": "BOOL"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "field_3",
+                "type": "FLOAT64"
+              }
+            ],
+            "mode": "NULLABLE",
+            "name": "namespace_1",
+            "type": "RECORD"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -607,27 +595,23 @@
           "name": "root",
           "type": "record"
         },
-        "bigquery": {
-          "fields": [
-            {
-              "mode": "REQUIRED",
-              "name": "shared",
-              "type": "INT64"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "type_a",
-              "type": "INT64"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "type_b",
-              "type": "INT64"
-            }
-          ],
-          "mode": "REQUIRED",
-          "type": "RECORD"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "shared",
+            "type": "INT64"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "type_a",
+            "type": "INT64"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "type_b",
+            "type": "INT64"
+          }
+        ],
         "json": {
           "oneOf": [
             {

--- a/tests/resources/oneof.json
+++ b/tests/resources/oneof.json
@@ -7,10 +7,13 @@
         "avro": {
           "type": "long"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "INT64"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "INT64"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -34,10 +37,13 @@
             "type": "long"
           }
         ],
-        "bigquery": {
-          "mode": "NULLABLE",
-          "type": "INT64"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "root",
+            "type": "INT64"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -56,10 +62,13 @@
         "avro": {
           "type": "string"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "STRING"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -87,10 +96,13 @@
             "type": "string"
           }
         ],
-        "bigquery": {
-          "mode": "NULLABLE",
-          "type": "STRING"
-        },
+        "bigquery": [
+          {
+            "mode": "NULLABLE",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -446,10 +458,13 @@
         "avro": {
           "type": "string"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "STRING"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -473,10 +488,13 @@
         "avro": {
           "type": "string"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "STRING"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
         "json": {
           "oneOf": [
             {
@@ -511,10 +529,13 @@
         "avro": {
           "type": "string"
         },
-        "bigquery": {
-          "mode": "REQUIRED",
-          "type": "STRING"
-        },
+        "bigquery": [
+          {
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
         "json": {
           "oneOf": [
             {

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -173,10 +173,13 @@ fn bigquery_test_datetime() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "TIMESTAMP"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "TIMESTAMP"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -424,32 +424,28 @@ fn bigquery_test_object_with_atomics_is_sorted() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "field_1",
-          "type": "INT64"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_2",
-          "type": "STRING"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_3",
-          "type": "BOOL"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_4",
-          "type": "FLOAT64"
-        }
-      ],
-      "mode": "REQUIRED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "field_1",
+        "type": "INT64"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_3",
+        "type": "BOOL"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_4",
+        "type": "FLOAT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -479,27 +475,23 @@ fn bigquery_test_object_with_atomics_required() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "REQUIRED",
-          "name": "field_1",
-          "type": "INT64"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_2",
-          "type": "STRING"
-        },
-        {
-          "mode": "REQUIRED",
-          "name": "field_3",
-          "type": "BOOL"
-        }
-      ],
-      "mode": "REQUIRED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "field_1",
+        "type": "INT64"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "field_3",
+        "type": "BOOL"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -532,27 +524,23 @@ fn bigquery_test_object_with_atomics_required_with_null() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "field_1",
-          "type": "INT64"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_2",
-          "type": "STRING"
-        },
-        {
-          "mode": "REQUIRED",
-          "name": "field_3",
-          "type": "BOOL"
-        }
-      ],
-      "mode": "REQUIRED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "field_1",
+        "type": "INT64"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "field_3",
+        "type": "BOOL"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -580,29 +568,25 @@ fn bigquery_test_object_with_complex() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_1",
-              "type": "STRING"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "INT64"
-            }
-          ],
-          "mode": "NULLABLE",
-          "name": "namespace_1",
-          "type": "RECORD"
-        }
-      ],
-      "mode": "REQUIRED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "field_1",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_2",
+            "type": "INT64"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "namespace_1",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -762,22 +746,18 @@ fn bigquery_test_oneof_object_with_atomics() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "field_1",
-          "type": "INT64"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_2",
-          "type": "INT64"
-        }
-      ],
-      "mode": "REQUIRED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "field_1",
+        "type": "INT64"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_2",
+        "type": "INT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -815,27 +795,23 @@ fn bigquery_test_oneof_object_merge() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "field_1",
-          "type": "INT64"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_2",
-          "type": "BOOL"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_3",
-          "type": "FLOAT64"
-        }
-      ],
-      "mode": "REQUIRED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "field_1",
+        "type": "INT64"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_2",
+        "type": "BOOL"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_3",
+        "type": "FLOAT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -894,44 +870,40 @@ fn bigquery_test_oneof_object_merge_with_complex() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "field_4",
-          "type": "BOOL"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_5",
-          "type": "FLOAT64"
-        },
-        {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_1",
-              "type": "INT64"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "BOOL"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_3",
-              "type": "FLOAT64"
-            }
-          ],
-          "mode": "NULLABLE",
-          "name": "namespace_1",
-          "type": "RECORD"
-        }
-      ],
-      "mode": "REQUIRED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "field_4",
+        "type": "BOOL"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "field_5",
+        "type": "FLOAT64"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "field_1",
+            "type": "INT64"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_2",
+            "type": "BOOL"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_3",
+            "type": "FLOAT64"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "namespace_1",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -1091,27 +1063,23 @@ fn bigquery_test_oneof_object_merge_nullability() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "REQUIRED",
-          "name": "shared",
-          "type": "INT64"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "type_a",
-          "type": "INT64"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "type_b",
-          "type": "INT64"
-        }
-      ],
-      "mode": "REQUIRED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "shared",
+        "type": "INT64"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "type_a",
+        "type": "INT64"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "type_b",
+        "type": "INT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -13,10 +13,13 @@ fn bigquery_test_array_with_atomics() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REPEATED",
-      "type": "INT64"
-    }
+    [
+      {
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "INT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -42,22 +45,25 @@ fn bigquery_test_array_with_complex() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "field_1",
-          "type": "STRING"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "field_2",
-          "type": "INT64"
-        }
-      ],
-      "mode": "REPEATED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "field_1",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "field_2",
+            "type": "INT64"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -72,10 +78,13 @@ fn bigquery_test_atomic() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "INT64"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "INT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -93,10 +102,13 @@ fn bigquery_test_atomic_with_null() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "NULLABLE",
-      "type": "INT64"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "root",
+        "type": "INT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -114,10 +126,13 @@ fn bigquery_test_incompatible_atomic_multitype() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "STRING"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -136,10 +151,13 @@ fn bigquery_test_incompatible_atomic_multitype_with_null() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "NULLABLE",
-      "type": "STRING"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -176,22 +194,25 @@ fn bigquery_test_map_with_atomics() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "REQUIRED",
-          "name": "key",
-          "type": "STRING"
-        },
-        {
-          "mode": "REQUIRED",
-          "name": "value",
-          "type": "INT64"
-        }
-      ],
-      "mode": "REPEATED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "key",
+            "type": "STRING"
+          },
+          {
+            "mode": "REQUIRED",
+            "name": "value",
+            "type": "INT64"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -217,34 +238,37 @@ fn bigquery_test_map_with_complex() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "REQUIRED",
-          "name": "key",
-          "type": "STRING"
-        },
-        {
-          "fields": [
-            {
-              "mode": "NULLABLE",
-              "name": "field_1",
-              "type": "STRING"
-            },
-            {
-              "mode": "NULLABLE",
-              "name": "field_2",
-              "type": "INT64"
-            }
-          ],
-          "mode": "REQUIRED",
-          "name": "value",
-          "type": "RECORD"
-        }
-      ],
-      "mode": "REPEATED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "key",
+            "type": "STRING"
+          },
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "field_1",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "field_2",
+                "type": "INT64"
+              }
+            ],
+            "mode": "REQUIRED",
+            "name": "value",
+            "type": "RECORD"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -265,22 +289,25 @@ fn bigquery_test_map_with_pattern_properties() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "REQUIRED",
-          "name": "key",
-          "type": "STRING"
-        },
-        {
-          "mode": "REQUIRED",
-          "name": "value",
-          "type": "INT64"
-        }
-      ],
-      "mode": "REPEATED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "key",
+            "type": "STRING"
+          },
+          {
+            "mode": "REQUIRED",
+            "name": "value",
+            "type": "INT64"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -303,22 +330,25 @@ fn bigquery_test_map_with_pattern_and_additional_properties() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "REQUIRED",
-          "name": "key",
-          "type": "STRING"
-        },
-        {
-          "mode": "REQUIRED",
-          "name": "value",
-          "type": "INT64"
-        }
-      ],
-      "mode": "REPEATED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "key",
+            "type": "STRING"
+          },
+          {
+            "mode": "REQUIRED",
+            "name": "value",
+            "type": "INT64"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -342,22 +372,25 @@ fn bigquery_test_incompatible_map_with_pattern_properties() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "REQUIRED",
-          "name": "key",
-          "type": "STRING"
-        },
-        {
-          "mode": "REQUIRED",
-          "name": "value",
-          "type": "STRING"
-        }
-      ],
-      "mode": "REPEATED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "key",
+            "type": "STRING"
+          },
+          {
+            "mode": "REQUIRED",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -380,22 +413,25 @@ fn bigquery_test_incompatible_map_with_pattern_and_additional_properties() {
     }
     "#;
     let expected_data = r#"
-    {
-      "fields": [
-        {
-          "mode": "REQUIRED",
-          "name": "key",
-          "type": "STRING"
-        },
-        {
-          "mode": "REQUIRED",
-          "name": "value",
-          "type": "STRING"
-        }
-      ],
-      "mode": "REPEATED",
-      "type": "RECORD"
-    }
+    [
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "key",
+            "type": "STRING"
+          },
+          {
+            "mode": "REQUIRED",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "RECORD"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -602,10 +638,13 @@ fn bigquery_test_object_empty_record() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "STRING"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -627,10 +666,13 @@ fn bigquery_test_oneof_atomic() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "INT64"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "INT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -652,10 +694,13 @@ fn bigquery_test_oneof_atomic_with_null() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "NULLABLE",
-      "type": "INT64"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "root",
+        "type": "INT64"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -677,10 +722,13 @@ fn bigquery_test_incompatible_oneof_atomic() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "STRING"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -705,10 +753,13 @@ fn bigquery_test_incompatible_oneof_atomic_with_null() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "NULLABLE",
-      "type": "STRING"
-    }
+    [
+      {
+        "mode": "NULLABLE",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -930,10 +981,13 @@ fn bigquery_test_incompatible_oneof_atomic_and_object() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "STRING"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -965,10 +1019,13 @@ fn bigquery_test_incompatible_oneof_object() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "STRING"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
@@ -1016,10 +1073,13 @@ fn bigquery_test_incompatible_oneof_object_with_complex() {
     }
     "#;
     let expected_data = r#"
-    {
-      "mode": "REQUIRED",
-      "type": "STRING"
-    }
+    [
+      {
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();


### PR DESCRIPTION
This will fix #51 by making the starting the resulting BigQuery schema as a list of elements.

EDIT: This is ready for review. See https://github.com/mozilla/jsonschema-transpiler/pull/61#issuecomment-488427937

---
There are currently 5 failures:

```
failures:
    bigquery_test_object_empty_record
    bigquery_test_oneof_object_merge
    bigquery_test_oneof_object_merge_nullability
    bigquery_test_oneof_object_merge_with_complex
    bigquery_test_oneof_object_with_atomics

test result: FAILED. 23 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out
```

In particular, the edge case that needs to be captured is the empty schema. Should the resulting table be an empty schema i.e. `[]`?

```json
    {
      "description": [
        "Empty structs are not supported in BigQuery, so we treat them ",
        "as empty documents."
      ],
      "name": "test_object_empty_record",
      "test": {
        "avro": {
          "type": "string"
        },
        "bigquery": {
          "mode": "REQUIRED",
          "type": "STRING"
        },
        "json": {
          "properties": {},
          "type": "object"
        }
      }
    }
```

I suspect there may need to be changes to the avro implementation too. However, all real-world documents will never reach this edge-case due to valid metadata. 
