### PR TITLE
Use timestamp rather than datetime in bq

### DIFF
--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -95,7 +95,7 @@ impl From<ast::Tag> for Tag {
                 ast::Atom::Integer => Atom::Int64,
                 ast::Atom::Number => Atom::Float64,
                 ast::Atom::String => Atom::String,
-                ast::Atom::Datetime => Atom::Datetime,
+                ast::Atom::Datetime => Atom::Timestamp,
                 ast::Atom::JSON => {
                     warn!(
                         "{} - Treating subschema as JSON string",
@@ -524,7 +524,7 @@ mod tests {
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
         let bq: Tag = jschema.into();
         let expect = json!({
-           "type": "DATETIME",
+           "type": "TIMESTAMP",
            "mode": "NULLABLE",
         });
         assert_eq!(expect, json!(bq));

--- a/tests/resources/atomic.json
+++ b/tests/resources/atomic.json
@@ -96,7 +96,7 @@
         },
         "bigquery": {
           "mode": "REQUIRED",
-          "type": "DATETIME"
+          "type": "TIMESTAMP"
         },
         "json": {
           "format": "date-time",

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -157,7 +157,7 @@ fn bigquery_test_datetime() {
     let expected_data = r#"
     {
       "mode": "REQUIRED",
-      "type": "DATETIME"
+      "type": "TIMESTAMP"
     }
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();


### PR DESCRIPTION
TIMESTAMP type can be partioned on, but DATETIME cannot.

I ain't angry, but I'm angry.