### PR TITLE
Ignore hidden test resource files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -146,7 +146,7 @@ use serde_json::Value;
         .map(|e| e.unwrap().path())
         .filter(|e| match e.file_name() {
             Some(os_str) => !os_str.to_str().unwrap().starts_with("."),
-            None => false
+            None => false,
         })
         .collect();
     paths.sort();

--- a/build.rs
+++ b/build.rs
@@ -144,6 +144,10 @@ use serde_json::Value;
     let mut paths: Vec<_> = fs::read_dir(test_cases)
         .unwrap()
         .map(|e| e.unwrap().path())
+        .filter(|e| match e.file_name() {
+            Some(os_str) => !os_str.to_str().unwrap().starts_with("."),
+            None => false
+        })
         .collect();
     paths.sort();
     for path in paths {


### PR DESCRIPTION
This makes working on these files in your editor of choice a bit easier, because you don't need to close and/or delete workspace files (e.g. `.swp` files in vim).