### PR TITLE
Add a flag to drop fields instead of casting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -13,7 +13,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -21,19 +21,19 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -43,7 +43,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -52,11 +52,11 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -66,14 +66,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -86,20 +86,20 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jsonschema-transpiler"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.48"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -117,7 +117,7 @@ name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -126,11 +126,16 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -139,14 +144,14 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.25"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,15 +164,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.6.10"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.51"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -175,24 +180,24 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "1.1.2"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -200,35 +205,35 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.84"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.84"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.35"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -238,17 +243,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.26"
+version = "0.15.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -256,11 +261,12 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -297,7 +303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -307,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -324,7 +330,7 @@ name = "winapi-util"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -337,51 +343,52 @@ name = "wincolor"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+"checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
+"checksum ctor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3b4c17619643c1252b5f690084b82639dd7fac141c57c8e77a00e0148132092c"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-"checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
+"checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
-"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
-"checksum proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)" = "d3797b7142c9aa74954e351fc089bbee7958cebbff6bf2815e7ffff0b19f547d"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
-"checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
+"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
+"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f"
-"checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
-"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)" = "0e732ed5a5592c17d961555e3b552985baf98d50ce418b7b655f31f6ba7eb1b7"
-"checksum serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d6115a3ca25c224e409185325afc16a0d5aaaabc15c42b09587d6f1ba39a5b"
-"checksum serde_json 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "dfb1277d4d0563e4593e0b8b5d23d744d277b55d2bc0bf1c38d0d8a6589d38aa"
+"checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
+"checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
+"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)" = "076a696fdea89c19d3baed462576b8f6d663064414b5c793642da8dfeb99475b"
+"checksum serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)" = "ef45eb79d6463b22f5f9e16d283798b7c0175ba6050bc25c1a946c122727fe7b"
+"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
-"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
-"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
+"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonschema-transpiler"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Anthony Miyaguchi <amiyaguchi@mozilla.com>"]
 description = "A tool to transpile JSON Schema into schemas for data processing"
 license = "MPL-2.0"

--- a/build.rs
+++ b/build.rs
@@ -78,7 +78,9 @@ fn avro_{name}() {{
     let expected_data = r#"
     {expected}
     "#;
-    let context = Context {{ resolve_method: ResolveMethod::Cast }};
+    let context = Context {{
+        resolve_method: ResolveMethod::Cast,
+    }};
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -104,7 +106,9 @@ fn bigquery_{name}() {{
     let expected_data = r#"
     {expected}
     "#;
-    let context = Context {{ resolve_method: ResolveMethod::Cast }};
+    let context = Context {{
+        resolve_method: ResolveMethod::Cast,
+    }};
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));

--- a/build.rs
+++ b/build.rs
@@ -78,9 +78,10 @@ fn avro_{name}() {{
     let expected_data = r#"
     {expected}
     "#;
+    let context = Context {{ resolve_method: ResolveMethod::Cast }};
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }}
 "##,
             name = case.name,
@@ -103,9 +104,10 @@ fn bigquery_{name}() {{
     let expected_data = r#"
     {expected}
     "#;
+    let context = Context {{ resolve_method: ResolveMethod::Cast }};
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }}
 "##,
             name = case.name,
@@ -126,6 +128,7 @@ fn main() {
     write!(
         avro_fp,
         r#"use jst::convert_avro;
+use jst::{{Context, ResolveMethod}};
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 "#
@@ -135,6 +138,7 @@ use serde_json::Value;
     write!(
         bq_fp,
         r#"use jst::convert_bigquery;
+use jst::{{Context, ResolveMethod}};
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 "#

--- a/build.rs
+++ b/build.rs
@@ -83,7 +83,7 @@ fn avro_{name}() {{
     }};
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }}
 "##,
             name = case.name,
@@ -111,7 +111,7 @@ fn bigquery_{name}() {{
     }};
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }}
 "##,
             name = case.name,

--- a/build.rs
+++ b/build.rs
@@ -80,7 +80,7 @@ fn avro_{name}() {{
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }}
 "##,
             name = case.name,
@@ -105,7 +105,7 @@ fn bigquery_{name}() {{
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }}
 "##,
             name = case.name,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,6 +1,6 @@
 use super::jsonschema;
-use super::traits::Translate;
 use super::Context;
+use super::TranslateFrom;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
@@ -504,10 +504,10 @@ impl Tag {
     }
 }
 
-impl Translate<jsonschema::Tag> for Tag {
+impl TranslateFrom<jsonschema::Tag> for Tag {
     type Error = &'static str;
 
-    fn translate(tag: jsonschema::Tag, _context: Option<Context>) -> Result<Self, Self::Error> {
+    fn translate_from(tag: jsonschema::Tag, _context: Option<Context>) -> Result<Self, Self::Error> {
         let mut tag = tag.type_into_ast();
         tag.infer_name();
         tag.infer_nullability();

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -507,7 +507,10 @@ impl Tag {
 impl TranslateFrom<jsonschema::Tag> for Tag {
     type Error = &'static str;
 
-    fn translate_from(tag: jsonschema::Tag, _context: Option<Context>) -> Result<Self, Self::Error> {
+    fn translate_from(
+        tag: jsonschema::Tag,
+        _context: Option<Context>,
+    ) -> Result<Self, Self::Error> {
         let mut tag = tag.type_into_ast();
         tag.infer_name();
         tag.infer_nullability();

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,5 @@
 use super::jsonschema;
+use super::traits::{Translate, TranslateInto};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
@@ -504,13 +505,15 @@ impl Tag {
     }
 }
 
-impl From<jsonschema::Tag> for Tag {
-    fn from(tag: jsonschema::Tag) -> Self {
+impl Translate<jsonschema::Tag> for Tag {
+    type Error = &'static str;
+
+    fn translate(tag: jsonschema::Tag) -> Result<Self, Self::Error> {
         let mut tag = tag.type_into_ast();
         tag.infer_name();
         tag.infer_nullability();
         tag.is_root = true;
-        tag
+        Ok(tag)
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -507,10 +507,7 @@ impl Tag {
 impl TranslateFrom<jsonschema::Tag> for Tag {
     type Error = &'static str;
 
-    fn translate_from(
-        tag: jsonschema::Tag,
-        _context: Option<Context>,
-    ) -> Result<Self, Self::Error> {
+    fn translate_from(tag: jsonschema::Tag, _context: Context) -> Result<Self, Self::Error> {
         let mut tag = tag.type_into_ast();
         tag.infer_name();
         tag.infer_nullability();

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,6 @@
 use super::jsonschema;
 use super::traits::{Translate, TranslateInto};
+use super::Context;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
@@ -508,7 +509,7 @@ impl Tag {
 impl Translate<jsonschema::Tag> for Tag {
     type Error = &'static str;
 
-    fn translate(tag: jsonschema::Tag) -> Result<Self, Self::Error> {
+    fn translate(tag: jsonschema::Tag, context: Option<Context>) -> Result<Self, Self::Error> {
         let mut tag = tag.type_into_ast();
         tag.infer_name();
         tag.infer_nullability();

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,5 @@
 use super::jsonschema;
-use super::traits::{Translate, TranslateInto};
+use super::traits::Translate;
 use super::Context;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
@@ -79,14 +79,12 @@ impl Map {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Union {
-    items: Vec<Box<Tag>>,
+    items: Vec<Tag>,
 }
 
 impl Union {
     pub fn new(items: Vec<Tag>) -> Self {
-        Union {
-            items: items.into_iter().map(Box::new).collect(),
-        }
+        Union { items }
     }
 
     /// Collapse a union of types into a structurally compatible type.
@@ -97,7 +95,7 @@ impl Union {
     /// be consumed by the JSON type. In a similar fashion, a table schema is determined
     /// to be nullable or required via occurances of null types in unions.
     pub fn collapse(&self) -> Tag {
-        let is_null = self.items.iter().any(|x| x.is_null());
+        let is_null = self.items.iter().any(Tag::is_null);
 
         if self.items.is_empty() {
             panic!("empty union is not allowed")
@@ -111,7 +109,7 @@ impl Union {
             };
         }
 
-        let items: Vec<Box<Tag>> = self
+        let items: Vec<Tag> = self
             .items
             .iter()
             .filter(|x| !x.is_null())
@@ -119,7 +117,7 @@ impl Union {
                 if let Type::Union(union) = &x.data_type {
                     let mut tag = union.collapse();
                     tag.name = x.name.clone();
-                    Box::new(tag)
+                    tag
                 } else {
                     x.clone()
                 }
@@ -130,7 +128,7 @@ impl Union {
         // the preprocessing step, check for nullability based on the immediate level of tags
         let nullable = is_null || items.iter().any(|tag| tag.nullable);
 
-        let data_type: Type = if items.iter().all(|x| x.is_atom()) {
+        let data_type: Type = if items.iter().all(Tag::is_atom) {
             items
                 .into_iter()
                 .fold(Type::Null, |acc, x| match (acc, &x.data_type) {
@@ -155,7 +153,7 @@ impl Union {
                         Type::Atom(Atom::JSON)
                     }
                 })
-        } else if items.iter().all(|x| x.is_object()) {
+        } else if items.iter().all(Tag::is_object) {
             items
                 .into_iter()
                 .fold(Type::Null, |acc, x| match (&acc, &x.data_type) {
@@ -187,7 +185,7 @@ impl Union {
                             let required: Option<HashSet<String>> =
                                 match (&left.required, &right.required) {
                                     (Some(x), Some(y)) => {
-                                        Some(x.intersection(&y).map(|x| x.to_string()).collect())
+                                        Some(x.intersection(&y).map(ToString::to_string).collect())
                                     }
                                     (Some(x), None) | (None, Some(x)) => Some(x.clone()),
                                     _ => None,
@@ -203,7 +201,7 @@ impl Union {
                         Type::Atom(Atom::JSON)
                     }
                 })
-        } else if items.iter().all(|x| x.is_map()) {
+        } else if items.iter().all(Tag::is_map) {
             let tags: Vec<Tag> = items
                 .into_iter()
                 .map(|x| match &x.data_type {
@@ -212,7 +210,7 @@ impl Union {
                 })
                 .collect();
             Type::Map(Map::new(None, Union::new(tags).collapse()))
-        } else if items.iter().all(|x| x.is_array()) {
+        } else if items.iter().all(Tag::is_array) {
             let tags: Vec<Tag> = items
                 .into_iter()
                 .map(|x| match &x.data_type {
@@ -496,7 +494,7 @@ impl Tag {
                         .map(String::as_str)
                         .map(Tag::rename_string_bigquery)
                         .filter(Option::is_some)
-                        .map(|x| x.unwrap())
+                        .map(Option::unwrap)
                         .collect();
                     Some(renamed)
                 }
@@ -509,7 +507,7 @@ impl Tag {
 impl Translate<jsonschema::Tag> for Tag {
     type Error = &'static str;
 
-    fn translate(tag: jsonschema::Tag, context: Option<Context>) -> Result<Self, Self::Error> {
+    fn translate(tag: jsonschema::Tag, _context: Option<Context>) -> Result<Self, Self::Error> {
         let mut tag = tag.type_into_ast();
         tag.infer_name();
         tag.infer_nullability();
@@ -678,7 +676,7 @@ mod tests {
         };
         let union = Tag {
             data_type: Type::Union(Union {
-                items: vec![Box::new(test_int), Box::new(test_null)],
+                items: vec![test_int, test_null],
             }),
             ..Default::default()
         };

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -133,7 +133,7 @@ impl TranslateFrom<ast::Tag> for Type {
                         Primitive::String
                     }
                     ResolveMethod::Drop => return Err("json atom"),
-                    ResolveMethod::Panic => panic!("json atom"),
+                    ResolveMethod::Panic => panic!("{} - json atom", tag.fully_qualified_name()),
                 },
             }),
             ast::Type::Object(object) => {
@@ -167,8 +167,10 @@ impl TranslateFrom<ast::Tag> for Type {
                             warn!("{} - empty object", tag.fully_qualified_name());
                             Type::Primitive(Primitive::String)
                         }
-                        ResolveMethod::Panic => panic!("empty object"),
                         ResolveMethod::Drop => return Err("empty object"),
+                        ResolveMethod::Panic => {
+                            panic!("{} - empty object", tag.fully_qualified_name())
+                        }
                     }
                 } else {
                     fields.sort_by_key(|v| v.name.to_string());
@@ -204,8 +206,8 @@ impl TranslateFrom<ast::Tag> for Type {
                     warn!("{} - unsupported type", tag.fully_qualified_name());
                     Type::Primitive(Primitive::String)
                 }
-                ResolveMethod::Panic => panic!("unsupported type"),
                 ResolveMethod::Drop => return Err("unsupported type"),
+                ResolveMethod::Panic => panic!("{} - unsupported type", tag.fully_qualified_name()),
             },
         };
         if tag.nullable && !tag.is_null() {

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -129,10 +129,7 @@ impl TranslateFrom<ast::Tag> for Type {
                 ast::Atom::Datetime => Primitive::String,
                 ast::Atom::JSON => match context.resolve_method {
                     ResolveMethod::Cast => {
-                        warn!(
-                            "{} - Treating subschema as JSON string",
-                            tag.fully_qualified_name()
-                        );
+                        warn!("{} - json atom", tag.fully_qualified_name());
                         Primitive::String
                     }
                     ResolveMethod::Drop => return Err("json atom"),
@@ -167,13 +164,10 @@ impl TranslateFrom<ast::Tag> for Type {
                 if fields.is_empty() {
                     match context.resolve_method {
                         ResolveMethod::Cast => {
-                            warn!(
-                                "{} - Empty records are not supported, casting into a JSON string",
-                                tag.fully_qualified_name()
-                            );
+                            warn!("{} - empty object", tag.fully_qualified_name());
                             Type::Primitive(Primitive::String)
                         }
-                        ResolveMethod::Panic => panic!(),
+                        ResolveMethod::Panic => panic!("empty object"),
                         ResolveMethod::Drop => return Err("empty object"),
                     }
                 } else {
@@ -207,10 +201,10 @@ impl TranslateFrom<ast::Tag> for Type {
             },
             _ => match context.resolve_method {
                 ResolveMethod::Cast => {
-                    warn!("{} - Unsupported conversion", tag.fully_qualified_name());
+                    warn!("{} - unsupported type", tag.fully_qualified_name());
                     Type::Primitive(Primitive::String)
                 }
-                ResolveMethod::Panic => panic!(),
+                ResolveMethod::Panic => panic!("unsupported type"),
                 ResolveMethod::Drop => return Err("unsupported type"),
             },
         };

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -151,7 +151,11 @@ impl TranslateFrom<ast::Tag> for Type {
                         .iter()
                         .map(|(k, v)| {
                             let default = if v.nullable { Some(json!(null)) } else { None };
-                            (k.to_string(), Type::translate_from(*v.clone(), context), default)
+                            (
+                                k.to_string(),
+                                Type::translate_from(*v.clone(), context),
+                                default,
+                            )
                         })
                         .filter(|(_, v, _)| v.is_ok())
                         .map(|(name, data_type, default)| Field {

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -155,9 +155,9 @@ impl Translate<ast::Tag> for Type {
                         })
                         .filter(|(_, v, _)| v.is_ok())
                         .map(|(name, data_type, default)| Field {
-                            name: name,
+                            name,
                             data_type: data_type.unwrap(),
-                            default: default,
+                            default,
                             ..Default::default()
                         })
                         .collect()

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -347,7 +347,7 @@ mod tests {
         .unwrap();
 
         let test_int = match &*record.data_type {
-            Type::Record(record) => record.fields.get("test-int").unwrap(),
+            Type::Record(record) => &record.fields["test-int"],
             _ => panic!(),
         };
         match *test_int.data_type {
@@ -426,11 +426,11 @@ mod tests {
         });
         let record_a: Tag = serde_json::from_value(data).unwrap();
         let record_b = match &*record_a.data_type {
-            Type::Record(record) => record.fields.get("test-record-b").unwrap(),
+            Type::Record(record) => &record.fields["test-record-b"],
             _ => panic!(),
         };
         let test_int = match &*record_b.data_type {
-            Type::Record(record) => record.fields.get("test-int").unwrap(),
+            Type::Record(record) => &record.fields["test-int"],
             _ => panic!(),
         };
         match *test_int.data_type {

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -72,13 +72,10 @@ impl TranslateFrom<ast::Tag> for Tag {
                 ast::Atom::Datetime => Atom::Timestamp,
                 ast::Atom::JSON => match context.resolve_method {
                     ResolveMethod::Cast => {
-                        warn!(
-                            "{} - Treating subschema as JSON string",
-                            tag.fully_qualified_name()
-                        );
+                        warn!("{} - json atom", tag.fully_qualified_name());
                         Atom::String
                     }
-                    ResolveMethod::Panic => panic!(),
+                    ResolveMethod::Panic => panic!("json atom"),
                     ResolveMethod::Drop => {
                         return Err("json atom");
                     }
@@ -100,13 +97,10 @@ impl TranslateFrom<ast::Tag> for Tag {
                 if fields.is_empty() {
                     match context.resolve_method {
                         ResolveMethod::Cast => {
-                            warn!(
-                                "{} - Empty records are not supported, casting into a JSON string",
-                                tag.fully_qualified_name()
-                            );
+                            warn!("{} - empty object", tag.fully_qualified_name());
                             Type::Atom(Atom::String)
                         }
-                        ResolveMethod::Panic => panic!(),
+                        ResolveMethod::Panic => panic!("empty object"),
                         ResolveMethod::Drop => return Err("empty object"),
                     }
                 } else {
@@ -131,10 +125,10 @@ impl TranslateFrom<ast::Tag> for Tag {
             }
             _ => match context.resolve_method {
                 ResolveMethod::Cast => {
-                    warn!("{} - Unsupported conversion", tag.fully_qualified_name());
+                    warn!("{} - unsupported type", tag.fully_qualified_name());
                     Type::Atom(Atom::String)
                 }
-                ResolveMethod::Panic => panic!(),
+                ResolveMethod::Panic => panic!("unsupported type"),
                 ResolveMethod::Drop => return Err("unsupported type"),
             },
         };

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -75,10 +75,10 @@ impl TranslateFrom<ast::Tag> for Tag {
                         warn!("{} - json atom", tag.fully_qualified_name());
                         Atom::String
                     }
-                    ResolveMethod::Panic => panic!("json atom"),
                     ResolveMethod::Drop => {
                         return Err("json atom");
                     }
+                    ResolveMethod::Panic => panic!("{} - json atom", tag.fully_qualified_name()),
                 },
             }),
             ast::Type::Object(object) => {
@@ -100,8 +100,10 @@ impl TranslateFrom<ast::Tag> for Tag {
                             warn!("{} - empty object", tag.fully_qualified_name());
                             Type::Atom(Atom::String)
                         }
-                        ResolveMethod::Panic => panic!("empty object"),
                         ResolveMethod::Drop => return Err("empty object"),
+                        ResolveMethod::Panic => {
+                            panic!("{} - empty object", tag.fully_qualified_name())
+                        }
                     }
                 } else {
                     Type::Record(Record { fields })
@@ -128,8 +130,8 @@ impl TranslateFrom<ast::Tag> for Tag {
                     warn!("{} - unsupported type", tag.fully_qualified_name());
                     Type::Atom(Atom::String)
                 }
-                ResolveMethod::Panic => panic!("unsupported type"),
                 ResolveMethod::Drop => return Err("unsupported type"),
+                ResolveMethod::Panic => panic!("{} - unsupported type", tag.fully_qualified_name()),
             },
         };
 

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -1,5 +1,5 @@
 use super::ast;
-use super::traits::{Translate, TranslateInto};
+use super::traits::Translate;
 use super::{Context, ResolveMethod};
 use std::collections::HashMap;
 
@@ -241,6 +241,7 @@ mod fields_as_vec {
 
 #[cfg(test)]
 mod tests {
+    use super::super::traits::TranslateInto;
     use super::*;
     use pretty_assertions::assert_eq;
     use serde_json::{self, json, Value};

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -398,7 +398,7 @@ mod tests {
             "type": "null"
         });
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = jschema.translate_into().unwrap();
+        let bq: Tag = jschema.translate_into(None).unwrap();
         let expect = json!({
             "type": "STRING",
             "mode": "NULLABLE",
@@ -412,7 +412,7 @@ mod tests {
             "type": {"atom": "integer"}
         });
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = jschema.translate_into().unwrap();
+        let bq: Tag = jschema.translate_into(None).unwrap();
         let expect = json!({
             "type": "INT64",
             "mode": "REQUIRED",
@@ -427,7 +427,7 @@ mod tests {
             "nullable": true,
         });
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = jschema.translate_into().unwrap();
+        let bq: Tag = jschema.translate_into(None).unwrap();
         let expect = json!({
             "type": "INT64",
             "mode": "NULLABLE",
@@ -445,7 +445,7 @@ mod tests {
                     {"type": {"atom": "integer"}},
         ]}}});
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = jschema.translate_into().unwrap();
+        let bq: Tag = jschema.translate_into(None).unwrap();
         let expect = json!({
             "type": "INT64",
             "mode": "NULLABLE",
@@ -468,7 +468,7 @@ mod tests {
                                 "test-nested-atom": {"type": {"atom": "number"}}
                             }}}}}}}});
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = jschema.translate_into().unwrap();
+        let bq: Tag = jschema.translate_into(None).unwrap();
         let expect = json!({
             "type": "RECORD",
             "mode": "REQUIRED",
@@ -492,7 +492,7 @@ mod tests {
                     "type": {"atom": "integer"}},
         }}});
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = jschema.translate_into().unwrap();
+        let bq: Tag = jschema.translate_into(None).unwrap();
         let expect = json!({
             "type": "INT64",
             "mode": "REPEATED",
@@ -513,7 +513,7 @@ mod tests {
             }
         });
         let tag: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = tag.translate_into().unwrap();;
+        let bq: Tag = tag.translate_into(None).unwrap();;
         let expect = json!({
             "type": "STRING",
             "mode": "REQUIRED",
@@ -530,7 +530,7 @@ mod tests {
                 "value": {"type": {"atom": "integer"}}
         }}});
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = jschema.translate_into().unwrap();
+        let bq: Tag = jschema.translate_into(None).unwrap();
         let expect = json!({
         "type": "RECORD",
         "mode": "REPEATED",
@@ -548,7 +548,7 @@ mod tests {
             "nullable": true
         });
         let jschema: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Tag = jschema.translate_into().unwrap();
+        let bq: Tag = jschema.translate_into(None).unwrap();
         let expect = json!({
            "type": "TIMESTAMP",
            "mode": "NULLABLE",
@@ -561,7 +561,7 @@ mod tests {
         // Nameless tags are top-level fields that should be rooted by default
         let data = json!({"type": {"atom": "integer"}});
         let ast: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Schema = ast.translate_into().unwrap();
+        let bq: Schema = ast.translate_into(None).unwrap();
         let expect = json!([{
             "name": DEFAULT_COLUMN,
             "mode": "REQUIRED",
@@ -585,7 +585,7 @@ mod tests {
                                 "test-nested-atom": {"type": {"atom": "boolean"}}
                             }}}}}}}});
         let ast: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Schema = ast.translate_into().unwrap();;
+        let bq: Schema = ast.translate_into(None).unwrap();;
         let expect = json!([{
             "name": "test_object",
             "mode": "REQUIRED",
@@ -610,7 +610,7 @@ mod tests {
                 "value": {"type": {"atom": "integer"}}
         }}});
         let ast: ast::Tag = serde_json::from_value(data).unwrap();
-        let bq: Schema = ast.translate_into().unwrap();;
+        let bq: Schema = ast.translate_into(None).unwrap();;
         let expect = json!([{
             "name": "root",
             "type": "RECORD",

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -226,8 +226,18 @@ impl Tag {
 #[cfg(test)]
 mod tests {
     use super::super::traits::TranslateInto;
+    use super::super::{Context, ResolveMethod};
     use super::*;
     use pretty_assertions::assert_eq;
+
+    fn translate(data: Value) -> Value {
+        let context = Context {
+            resolve_method: ResolveMethod::Cast,
+        };
+        let schema: Tag = serde_json::from_value(data).unwrap();
+        let ast: ast::Tag = schema.translate_into(Some(context)).unwrap();
+        json!(ast)
+    }
 
     #[test]
     fn test_serialize_type_null() {
@@ -447,13 +457,11 @@ mod tests {
         let data = json!({
             "type": "null"
         });
-        let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
             "type": "null",
             "nullable": true,
         });
-        assert_eq!(expect, json!(ast))
+        assert_eq!(expect, translate(data))
     }
 
     #[test]
@@ -461,13 +469,11 @@ mod tests {
         let data = json!({
             "type": "integer"
         });
-        let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
             "type": {"atom": "integer"},
             "nullable": false,
         });
-        assert_eq!(expect, json!(ast))
+        assert_eq!(expect, translate(data))
     }
 
     #[test]
@@ -475,8 +481,6 @@ mod tests {
         let data = json!({
             "type": ["null", "integer"]
         });
-        let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
             "type": {
                 "union": {
@@ -495,7 +499,7 @@ mod tests {
             },
             "nullable": true,
         });
-        assert_eq!(expect, json!(ast))
+        assert_eq!(expect, translate(data))
     }
 
     #[test]
@@ -510,8 +514,6 @@ mod tests {
                 "properties": {
                     "test-null": {"type": "null"}
                 }}}});
-        let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -534,7 +536,7 @@ mod tests {
                                         "type": "null",
                                         "nullable": true,
                                     }}}}}}}}});
-        assert_eq!(expect, json!(ast))
+        assert_eq!(expect, translate(data))
     }
 
     #[test]
@@ -548,8 +550,6 @@ mod tests {
                 }
             }
         });
-        let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -571,7 +571,7 @@ mod tests {
                                     "nullable": true,
                                     "type": {"atom": "integer"}
                                 }}}}}}}});
-        assert_eq!(expect, json!(ast))
+        assert_eq!(expect, translate(data))
     }
 
     #[test]
@@ -582,8 +582,6 @@ mod tests {
                 "type": "integer"
             }
         });
-        let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -593,7 +591,7 @@ mod tests {
                     "nullable": false,
                     "type": {"atom": "integer"}
                 }}}});
-        assert_eq!(expect, json!(ast))
+        assert_eq!(expect, translate(data))
     }
 
     #[test]
@@ -604,8 +602,6 @@ mod tests {
                 {"type": "null"}
             ],
         });
-        let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
         "nullable": true,
         "type": {
@@ -622,7 +618,7 @@ mod tests {
                         "type": "null"
                     }
                 ]}}});
-        assert_eq!(expect, json!(ast))
+        assert_eq!(expect, translate(data))
     }
 
     #[test]
@@ -651,12 +647,10 @@ mod tests {
             "type": "string",
             "format": "date-time"
         });
-        let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
             "type": {"atom": "datetime"},
             "nullable": false,
         });
-        assert_eq!(expect, json!(ast))
+        assert_eq!(expect, translate(data))
     }
 }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -4,7 +4,6 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 use super::ast;
-use super::traits::TranslateInto;
 
 /// The type enumeration does not contain any data and is used to determine
 /// available fields in the flattened tag. In JSONSchema parlance, these are
@@ -188,7 +187,7 @@ impl Tag {
                                 Some(vec) => {
                                     let items: Vec<ast::Tag> =
                                         vec.iter().map(|item| item.type_into_ast()).collect();
-                                    let nullable: bool = items.iter().any(|x| x.is_null());
+                                    let nullable: bool = items.iter().any(ast::Tag::is_null);
                                     ast::Tag::new(
                                         ast::Type::Union(ast::Union::new(items)),
                                         None,
@@ -226,6 +225,7 @@ impl Tag {
 
 #[cfg(test)]
 mod tests {
+    use super::super::traits::TranslateInto;
     use super::*;
     use pretty_assertions::assert_eq;
 

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -4,6 +4,7 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 use super::ast;
+use super::traits::TranslateInto;
 
 /// The type enumeration does not contain any data and is used to determine
 /// available fields in the flattened tag. In JSONSchema parlance, these are
@@ -447,7 +448,7 @@ mod tests {
             "type": "null"
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.into();
+        let ast: ast::Tag = schema.translate_into().unwrap();
         let expect = json!({
             "type": "null",
             "nullable": true,
@@ -461,7 +462,7 @@ mod tests {
             "type": "integer"
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.into();
+        let ast: ast::Tag = schema.translate_into().unwrap();
         let expect = json!({
             "type": {"atom": "integer"},
             "nullable": false,
@@ -475,7 +476,7 @@ mod tests {
             "type": ["null", "integer"]
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.into();
+        let ast: ast::Tag = schema.translate_into().unwrap();
         let expect = json!({
             "type": {
                 "union": {
@@ -510,7 +511,7 @@ mod tests {
                     "test-null": {"type": "null"}
                 }}}});
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.into();
+        let ast: ast::Tag = schema.translate_into().unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -548,7 +549,7 @@ mod tests {
             }
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.into();
+        let ast: ast::Tag = schema.translate_into().unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -582,7 +583,7 @@ mod tests {
             }
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.into();
+        let ast: ast::Tag = schema.translate_into().unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -604,7 +605,7 @@ mod tests {
             ],
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.into();
+        let ast: ast::Tag = schema.translate_into().unwrap();
         let expect = json!({
         "nullable": true,
         "type": {
@@ -651,7 +652,7 @@ mod tests {
             "format": "date-time"
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.into();
+        let ast: ast::Tag = schema.translate_into().unwrap();
         let expect = json!({
             "type": {"atom": "datetime"},
             "nullable": false,

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -235,7 +235,7 @@ mod tests {
             resolve_method: ResolveMethod::Cast,
         };
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into(Some(context)).unwrap();
+        let ast: ast::Tag = schema.translate_into(context).unwrap();
         json!(ast)
     }
 

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -282,7 +282,7 @@ mod tests {
         let schema: Tag = serde_json::from_value(data).unwrap();
         let props = schema.object.properties.unwrap();
         assert_eq!(props.len(), 2);
-        let test_int = props.get("test-int").unwrap();
+        let test_int = &props["test-int"];
         assert_eq!(test_int.data_type, json!("integer"));
         assert_eq!(
             schema.object.required.unwrap(),

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -448,7 +448,7 @@ mod tests {
             "type": "null"
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into().unwrap();
+        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
             "type": "null",
             "nullable": true,
@@ -462,7 +462,7 @@ mod tests {
             "type": "integer"
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into().unwrap();
+        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
             "type": {"atom": "integer"},
             "nullable": false,
@@ -476,7 +476,7 @@ mod tests {
             "type": ["null", "integer"]
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into().unwrap();
+        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
             "type": {
                 "union": {
@@ -511,7 +511,7 @@ mod tests {
                     "test-null": {"type": "null"}
                 }}}});
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into().unwrap();
+        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -549,7 +549,7 @@ mod tests {
             }
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into().unwrap();
+        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -583,7 +583,7 @@ mod tests {
             }
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into().unwrap();
+        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
         "nullable": false,
         "type": {
@@ -605,7 +605,7 @@ mod tests {
             ],
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into().unwrap();
+        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
         "nullable": true,
         "type": {
@@ -652,7 +652,7 @@ mod tests {
             "format": "date-time"
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let ast: ast::Tag = schema.translate_into().unwrap();
+        let ast: ast::Tag = schema.translate_into(None).unwrap();
         let expect = json!({
             "type": {"atom": "datetime"},
             "nullable": false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,16 @@ mod traits;
 use serde_json::{json, Value};
 use traits::Translate;
 
+pub enum ResolveMethod {
+    Cast,
+    Drop,
+    Panic,
+}
+
+pub struct Context {
+    pub resolve_method: ResolveMethod,
+}
+
 fn into_ast(input: &Value) -> ast::Tag {
     let jsonschema: jsonschema::Tag = match serde_json::from_value(json!(input)) {
         Ok(tag) => tag,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,6 @@ pub fn convert_avro(input: &Value) -> Value {
 
 /// Convert JSON Schema into a BigQuery compatible schema
 pub fn convert_bigquery(input: &Value) -> Value {
-    let bq = bigquery::Schema::from(into_ast(input));
+    let bq = bigquery::Schema::translate(into_ast(input)).unwrap();
     json!(bq)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod jsonschema;
 mod traits;
 
 use serde_json::{json, Value};
-use traits::Translate;
+use traits::TranslateFrom;
 
 #[derive(Copy, Clone)]
 pub enum ResolveMethod {
@@ -32,17 +32,17 @@ fn into_ast(input: &Value, context: Option<Context>) -> ast::Tag {
         Ok(tag) => tag,
         Err(e) => panic!(format!("{:#?}", e)),
     };
-    ast::Tag::translate(jsonschema, context).unwrap()
+    ast::Tag::translate_from(jsonschema, context).unwrap()
 }
 
 /// Convert JSON Schema into an Avro compatible schema
 pub fn convert_avro(input: &Value, context: Option<Context>) -> Value {
-    let avro = avro::Type::translate(into_ast(input, context), context).unwrap();
+    let avro = avro::Type::translate_from(into_ast(input, context), context).unwrap();
     json!(avro)
 }
 
 /// Convert JSON Schema into a BigQuery compatible schema
 pub fn convert_bigquery(input: &Value, context: Option<Context>) -> Value {
-    let bq = bigquery::Schema::translate(into_ast(input, context), context).unwrap();
+    let bq = bigquery::Schema::translate_from(into_ast(input, context), context).unwrap();
     json!(bq)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,24 +15,25 @@ mod traits;
 use serde_json::{json, Value};
 use traits::TranslateFrom;
 
-/// Options for error handling in the [`TranslateFrom`] and [`TranslateInto`]
-/// interfaces for converting between schema formats.
+/// The error resoluton method in the [`TranslateFrom`] and [`TranslateInto`]
+/// interfaces when converting between schema formats.
 ///
 /// The `Cast` method will represent under-specified (e.g. empty objects) and
 /// incompatible (e.g. variant-types or conflicting oneOf definitions) as
 /// strings. This behavior is useful for compacting complex types into a single
 /// column. In Spark and BigQuery, a casted column can be processed via a user
-/// defined function that works on JSON. This method can cause issues with
-/// schema evolution that require migration work.
+/// defined function that works on JSON. However, this method may cause issues
+/// with schema evolution, for example when adding properties to empty objects.
 ///
 /// The `Drop` method will drop fields if they do not fall neatly into one of
 /// the supported types. This method ensures forward compatibility with schemas,
-/// but requires support during data processing to capture the dropped data from
-/// the structured section of the schema.
+/// but it can lose large portions of nested data. Support from the data
+/// processing side can recover dropped data from the structured section of the
+/// schema.
 ///
-/// The `Panic` method will panic if the JSON Schema is inconsistent in any way,
-/// or uses features that the transpiler does not support. This method is useful
-/// way to test for incompatible schemas.
+/// The `Panic` method will panic if the JSON Schema is inconsistent or uses
+/// unsupported features. This method is a useful way to test for incompatible
+/// schemas.
 #[derive(Copy, Clone)]
 pub enum ResolveMethod {
     Cast,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub struct Context {
     pub resolve_method: ResolveMethod,
 }
 
-fn into_ast(input: &Value, context: Option<Context>) -> ast::Tag {
+fn into_ast(input: &Value, context: Context) -> ast::Tag {
     let jsonschema: jsonschema::Tag = match serde_json::from_value(json!(input)) {
         Ok(tag) => tag,
         Err(e) => panic!(format!("{:#?}", e)),
@@ -36,13 +36,13 @@ fn into_ast(input: &Value, context: Option<Context>) -> ast::Tag {
 }
 
 /// Convert JSON Schema into an Avro compatible schema
-pub fn convert_avro(input: &Value, context: Option<Context>) -> Value {
+pub fn convert_avro(input: &Value, context: Context) -> Value {
     let avro = avro::Type::translate_from(into_ast(input, context), context).unwrap();
     json!(avro)
 }
 
 /// Convert JSON Schema into a BigQuery compatible schema
-pub fn convert_bigquery(input: &Value, context: Option<Context>) -> Value {
+pub fn convert_bigquery(input: &Value, context: Context) -> Value {
     let bq = bigquery::Schema::translate_from(into_ast(input, context), context).unwrap();
     json!(bq)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ fn into_ast(input: &Value) -> ast::Tag {
 
 /// Convert JSON Schema into an Avro compatible schema
 pub fn convert_avro(input: &Value) -> Value {
-    let avro = avro::Type::from(into_ast(input));
+    let avro = avro::Type::translate(into_ast(input)).unwrap();
     json!(avro)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,32 +15,34 @@ mod traits;
 use serde_json::{json, Value};
 use traits::Translate;
 
+#[derive(Copy, Clone)]
 pub enum ResolveMethod {
     Cast,
     Drop,
     Panic,
 }
 
+#[derive(Copy, Clone)]
 pub struct Context {
     pub resolve_method: ResolveMethod,
 }
 
-fn into_ast(input: &Value) -> ast::Tag {
+fn into_ast(input: &Value, context: Option<Context>) -> ast::Tag {
     let jsonschema: jsonschema::Tag = match serde_json::from_value(json!(input)) {
         Ok(tag) => tag,
         Err(e) => panic!(format!("{:#?}", e)),
     };
-    ast::Tag::translate(jsonschema).unwrap()
+    ast::Tag::translate(jsonschema, context).unwrap()
 }
 
 /// Convert JSON Schema into an Avro compatible schema
-pub fn convert_avro(input: &Value) -> Value {
-    let avro = avro::Type::translate(into_ast(input)).unwrap();
+pub fn convert_avro(input: &Value, context: Option<Context>) -> Value {
+    let avro = avro::Type::translate(into_ast(input, context), context).unwrap();
     json!(avro)
 }
 
 /// Convert JSON Schema into a BigQuery compatible schema
-pub fn convert_bigquery(input: &Value) -> Value {
-    let bq = bigquery::Schema::translate(into_ast(input)).unwrap();
+pub fn convert_bigquery(input: &Value, context: Option<Context>) -> Value {
+    let bq = bigquery::Schema::translate(into_ast(input, context), context).unwrap();
     json!(bq)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,15 +10,17 @@ mod ast;
 mod avro;
 mod bigquery;
 mod jsonschema;
+mod traits;
 
 use serde_json::{json, Value};
+use traits::Translate;
 
 fn into_ast(input: &Value) -> ast::Tag {
     let jsonschema: jsonschema::Tag = match serde_json::from_value(json!(input)) {
         Ok(tag) => tag,
         Err(e) => panic!(format!("{:#?}", e)),
     };
-    ast::Tag::from(jsonschema)
+    ast::Tag::translate(jsonschema).unwrap()
 }
 
 /// Convert JSON Schema into an Avro compatible schema

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use std::fs::File;
 use std::io::{self, BufReader};
 
 fn main() {
+    env_logger::init();
+
     let matches = App::new(env!("CARGO_PKG_NAME"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,8 @@ fn main() {
     };
 
     let output = match matches.value_of("type").unwrap() {
-        "avro" => jst::convert_avro(&data),
-        "bigquery" => jst::convert_bigquery(&data),
+        "avro" => jst::convert_avro(&data, context),
+        "bigquery" => jst::convert_bigquery(&data, context),
         _ => panic!("Unknown type!"),
     };
     let pretty = serde_json::to_string_pretty(&output).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,19 +48,13 @@ fn main() {
         None => Box::new(io::stdin()),
     };
     let data: Value = serde_json::from_reader(reader).unwrap();
-    let context: Option<Context> = match matches.value_of("resolve") {
-        Some(resolve) => {
-            let method = match resolve {
-                "cast" => ResolveMethod::Cast,
-                "panic" => ResolveMethod::Panic,
-                "drop" => ResolveMethod::Drop,
-                _ => panic!("Unknown resolution method!"),
-            };
-            Some(Context {
-                resolve_method: method,
-            })
-        }
-        None => None,
+    let context = Context {
+        resolve_method: match matches.value_of("resolve").unwrap() {
+            "cast" => ResolveMethod::Cast,
+            "panic" => ResolveMethod::Panic,
+            "drop" => ResolveMethod::Drop,
+            _ => panic!("Unknown resolution method!"),
+        },
     };
 
     let output = match matches.value_of("type").unwrap() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate env_logger;
 extern crate jst;
 
 use clap::{App, Arg};
+use jst::{Context, ResolveMethod};
 use serde_json::Value;
 use std::fs::File;
 use std::io::{self, BufReader};
@@ -13,7 +14,7 @@ fn main() {
     let matches = App::new(env!("CARGO_PKG_NAME"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .arg(
-            Arg::with_name("FILE")
+            Arg::with_name("file")
                 .help("Sets the input file to use")
                 .takes_value(true)
                 .index(1),
@@ -27,9 +28,18 @@ fn main() {
                 .possible_values(&["avro", "bigquery"])
                 .default_value("avro"),
         )
+        .arg(
+            Arg::with_name("resolve")
+                .help("The resolution strategy for incompatible or under-specified schema")
+                .short("r")
+                .long("resolve")
+                .takes_value(true)
+                .possible_values(&["cast", "panic", "drop"])
+                .default_value("cast"),
+        )
         .get_matches();
 
-    let reader: Box<io::Read> = match matches.value_of("FILE") {
+    let reader: Box<io::Read> = match matches.value_of("file") {
         Some(path) if path == "-" => Box::new(io::stdin()),
         Some(path) => {
             let file = File::open(path).unwrap();
@@ -38,6 +48,20 @@ fn main() {
         None => Box::new(io::stdin()),
     };
     let data: Value = serde_json::from_reader(reader).unwrap();
+    let context: Option<Context> = match matches.value_of("resolve") {
+        Some(resolve) => {
+            let method = match resolve {
+                "cast" => ResolveMethod::Cast,
+                "panic" => ResolveMethod::Panic,
+                "drop" => ResolveMethod::Drop,
+                _ => panic!("Unknown resolution method!"),
+            };
+            Some(Context {
+                resolve_method: method,
+            })
+        }
+        None => None,
+    };
 
     let output = match matches.value_of("type").unwrap() {
         "avro" => jst::convert_avro(&data),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,13 +4,13 @@ use super::Context;
 pub trait TranslateFrom<T>: Sized {
     type Error;
 
-    fn translate_from(value: T, context: Option<Context>) -> Result<Self, Self::Error>;
+    fn translate_from(value: T, context: Context) -> Result<Self, Self::Error>;
 }
 
 pub trait TranslateInto<T>: Sized {
     type Error;
 
-    fn translate_into(self, context: Option<Context>) -> Result<T, Self::Error>;
+    fn translate_into(self, context: Context) -> Result<T, Self::Error>;
 }
 
 // TranslateFrom implies TranslateInto
@@ -19,7 +19,7 @@ where
     U: TranslateFrom<T>,
 {
     type Error = U::Error;
-    fn translate_into(self, context: Option<Context>) -> Result<U, U::Error> {
+    fn translate_into(self, context: Context) -> Result<U, U::Error> {
         U::translate_from(self, context)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,14 +1,16 @@
+use super::Context;
+
 // https://doc.rust-lang.org/src/core/convert.rs.html#478-486
 pub trait Translate<T>: Sized {
     type Error;
 
-    fn translate(value: T) -> Result<Self, Self::Error>;
+    fn translate(value: T, context: Option<Context>) -> Result<Self, Self::Error>;
 }
 
 pub trait TranslateInto<T>: Sized {
     type Error;
 
-    fn translate_into(self) -> Result<T, Self::Error>;
+    fn translate_into(self, context: Option<Context>) -> Result<T, Self::Error>;
 }
 
 // Translate implies TranslateInto
@@ -17,7 +19,7 @@ where
     U: Translate<T>,
 {
     type Error = U::Error;
-    fn translate_into(self) -> Result<U, U::Error> {
-        U::translate(self)
+    fn translate_into(self, context: Option<Context>) -> Result<U, U::Error> {
+        U::translate(self, context)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,10 +1,10 @@
 use super::Context;
 
 // https://doc.rust-lang.org/src/core/convert.rs.html#478-486
-pub trait Translate<T>: Sized {
+pub trait TranslateFrom<T>: Sized {
     type Error;
 
-    fn translate(value: T, context: Option<Context>) -> Result<Self, Self::Error>;
+    fn translate_from(value: T, context: Option<Context>) -> Result<Self, Self::Error>;
 }
 
 pub trait TranslateInto<T>: Sized {
@@ -13,13 +13,13 @@ pub trait TranslateInto<T>: Sized {
     fn translate_into(self, context: Option<Context>) -> Result<T, Self::Error>;
 }
 
-// Translate implies TranslateInto
+// TranslateFrom implies TranslateInto
 impl<T, U> TranslateInto<U> for T
 where
-    U: Translate<T>,
+    U: TranslateFrom<T>,
 {
     type Error = U::Error;
     fn translate_into(self, context: Option<Context>) -> Result<U, U::Error> {
-        U::translate(self, context)
+        U::translate_from(self, context)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,12 +1,24 @@
 use super::Context;
 
-// https://doc.rust-lang.org/src/core/convert.rs.html#478-486
+/// A translation between two schema formats that may fail under certain
+/// conditions.
+///
+/// This is the similar to the `TryFrom` trait, but also requires the
+/// implementor to include a context struct for run-time modifications to the
+/// schema. The most concrete use of the context struct is to provide an
+/// appropriate error handling mechanism when the JSON Schema contains an empty
+/// field. Depending on the use-case, it may be more appropriate to signal
+/// immediate failure over something like dropping the field.
+///
+/// https://doc.rust-lang.org/src/core/convert.rs.html#478-486
 pub trait TranslateFrom<T>: Sized {
     type Error;
 
     fn translate_from(value: T, context: Context) -> Result<Self, Self::Error>;
 }
 
+/// A translation between two schema formats. It is the reciprocal of
+/// [`TranslateFrom']
 pub trait TranslateInto<T>: Sized {
     type Error;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,23 @@
+// https://doc.rust-lang.org/src/core/convert.rs.html#478-486
+pub trait Translate<T>: Sized {
+    type Error;
+
+    fn translate(value: T) -> Result<Self, Self::Error>;
+}
+
+pub trait TranslateInto<T>: Sized {
+    type Error;
+
+    fn translate_into(self) -> Result<T, Self::Error>;
+}
+
+// Translate implies TranslateInto
+impl<T, U> TranslateInto<U> for T
+where
+    U: Translate<T>,
+{
+    type Error = U::Error;
+    fn translate_into(self) -> Result<U, U::Error> {
+        U::translate(self)
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,12 +3,11 @@ use super::Context;
 /// A translation between two schema formats that may fail under certain
 /// conditions.
 ///
-/// This is the similar to the `TryFrom` trait, but also requires the
-/// implementor to include a context struct for run-time modifications to the
-/// schema. The most concrete use of the context struct is to provide an
-/// appropriate error handling mechanism when the JSON Schema contains an empty
-/// field. Depending on the use-case, it may be more appropriate to signal
-/// immediate failure over something like dropping the field.
+/// This is similar to the `TryFrom` trait, but requires the implementor to pass
+/// a Context struct for runtime modifications to the schema. A concrete use
+/// context is to decide on an appropriate error handling mechanism when a JSON
+/// Schema contains an empty field. Given a use-case, it may be more appropriate
+/// to fail fast and panic over dropping or casting the field.
 ///
 /// https://doc.rust-lang.org/src/core/convert.rs.html#478-486
 pub trait TranslateFrom<T>: Sized {

--- a/tests/resolve_method.rs
+++ b/tests/resolve_method.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 #[test]
 fn test_bigquery_object_error_resolution() {
     let mut expected: Value;
-    let mut context: Option<Context>;
+    let mut context: Context;
 
     let input: Value = serde_json::from_str(
         r#"
@@ -38,9 +38,9 @@ fn test_bigquery_object_error_resolution() {
     )
     .unwrap();
 
-    context = Some(Context {
+    context = Context {
         resolve_method: ResolveMethod::Cast,
-    });
+    };
     assert_eq!(expected, convert_bigquery(&input, context));
 
     expected = serde_json::from_str(
@@ -55,21 +55,21 @@ fn test_bigquery_object_error_resolution() {
         "#,
     )
     .unwrap();
-    context = Some(Context {
+    context = Context {
         resolve_method: ResolveMethod::Drop,
-    });
+    };
     assert_eq!(expected, convert_bigquery(&input, context));
 
-    context = Some(Context {
+    context = Context {
         resolve_method: ResolveMethod::Panic,
-    });
+    };
     assert!(std::panic::catch_unwind(|| convert_bigquery(&input, context)).is_err());
 }
 
 #[test]
 fn test_avro_object_error_resolution() {
     let mut expected: Value;
-    let mut context: Option<Context>;
+    let mut context: Context;
 
     let input: Value = serde_json::from_str(
         r#"
@@ -112,9 +112,9 @@ fn test_avro_object_error_resolution() {
     )
     .unwrap();
 
-    context = Some(Context {
+    context = Context {
         resolve_method: ResolveMethod::Cast,
-    });
+    };
     assert_eq!(expected, convert_avro(&input, context));
 
     expected = serde_json::from_str(
@@ -136,13 +136,13 @@ fn test_avro_object_error_resolution() {
         "#,
     )
     .unwrap();
-    context = Some(Context {
+    context = Context {
         resolve_method: ResolveMethod::Drop,
-    });
+    };
     assert_eq!(expected, convert_avro(&input, context));
 
-    context = Some(Context {
+    context = Context {
         resolve_method: ResolveMethod::Panic,
-    });
+    };
     assert!(std::panic::catch_unwind(|| convert_avro(&input, context)).is_err());
 }

--- a/tests/resolve_method.rs
+++ b/tests/resolve_method.rs
@@ -1,0 +1,67 @@
+use jst::convert_bigquery;
+use jst::{Context, ResolveMethod};
+use serde_json::Value;
+
+#[test]
+fn test_object_error_resolution() {
+    let mut expected: Value;
+    let mut context: Option<Context>;
+
+    let input: Value = serde_json::from_str(
+        r#"
+        {
+            "type": "object",
+            "properties": {
+                "empty": {},
+                "int": {"type": "integer"}
+            }
+        }
+        "#,
+    )
+    .unwrap();
+
+    expected = serde_json::from_str(
+        r#"
+        [
+            {
+                "mode": "NULLABLE",
+                "name": "empty",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "int",
+                "type": "INT64"
+            }
+        ]
+        "#,
+    )
+    .unwrap();
+
+    context = Some(Context {
+        resolve_method: ResolveMethod::Cast,
+    });
+    assert_eq!(expected, convert_bigquery(&input, context));
+
+    expected = serde_json::from_str(
+        r#"
+        [
+            {
+                "mode": "NULLABLE",
+                "name": "int",
+                "type": "INT64"
+            }
+        ]
+        "#,
+    )
+    .unwrap();
+    context = Some(Context {
+        resolve_method: ResolveMethod::Drop,
+    });
+    assert_eq!(expected, convert_bigquery(&input, context));
+
+    context = Some(Context {
+        resolve_method: ResolveMethod::Panic,
+    });
+    assert!(std::panic::catch_unwind(|| convert_bigquery(&input, context)).is_err());
+}

--- a/tests/resolve_method.rs
+++ b/tests/resolve_method.rs
@@ -64,11 +64,12 @@ fn test_bigquery_resolve_error_drop() {
 }
 
 #[test]
+#[should_panic]
 fn test_bigquery_resolve_error_panic() {
     let context = Context {
         resolve_method: ResolveMethod::Panic,
     };
-    assert!(std::panic::catch_unwind(|| convert_bigquery(&test_data(), context)).is_err());
+    convert_bigquery(&test_data(), context);
 }
 
 #[test]
@@ -135,9 +136,10 @@ fn test_avro_resolve_error_drop() {
 }
 
 #[test]
+#[should_panic]
 fn test_avro_resolve_error_panic() {
     let context = Context {
         resolve_method: ResolveMethod::Panic,
     };
-    assert!(std::panic::catch_unwind(|| convert_avro(&test_data(), context)).is_err());
+    convert_avro(&test_data(), context);
 }

--- a/tests/resolve_method.rs
+++ b/tests/resolve_method.rs
@@ -1,9 +1,9 @@
-use jst::convert_bigquery;
+use jst::{convert_avro, convert_bigquery};
 use jst::{Context, ResolveMethod};
 use serde_json::Value;
 
 #[test]
-fn test_object_error_resolution() {
+fn test_bigquery_object_error_resolution() {
     let mut expected: Value;
     let mut context: Option<Context>;
 
@@ -64,4 +64,85 @@ fn test_object_error_resolution() {
         resolve_method: ResolveMethod::Panic,
     });
     assert!(std::panic::catch_unwind(|| convert_bigquery(&input, context)).is_err());
+}
+
+#[test]
+fn test_avro_object_error_resolution() {
+    let mut expected: Value;
+    let mut context: Option<Context>;
+
+    let input: Value = serde_json::from_str(
+        r#"
+        {
+            "type": "object",
+            "properties": {
+                "empty": {},
+                "int": {"type": "integer"}
+            }
+        }
+        "#,
+    )
+    .unwrap();
+
+    expected = serde_json::from_str(
+        r#"
+        {
+            "fields": [
+                {
+                    "default": null,
+                    "name": "empty",
+                    "type": [
+                        {"type": "null"},
+                        {"type": "string"}
+                    ]
+                },
+                {
+                    "default": null,
+                    "name": "int",
+                    "type": [
+                        {"type": "null"},
+                        {"type": "long"}
+                    ]
+                }
+            ],
+            "name": "root",
+            "type": "record"
+        }
+        "#,
+    )
+    .unwrap();
+
+    context = Some(Context {
+        resolve_method: ResolveMethod::Cast,
+    });
+    assert_eq!(expected, convert_avro(&input, context));
+
+    expected = serde_json::from_str(
+        r#"
+        {
+            "fields": [
+                {
+                    "default": null,
+                    "name": "int",
+                    "type": [
+                        {"type": "null"},
+                        {"type": "long"}
+                    ]
+                }
+            ],
+            "name": "root",
+            "type": "record"
+        }
+        "#,
+    )
+    .unwrap();
+    context = Some(Context {
+        resolve_method: ResolveMethod::Drop,
+    });
+    assert_eq!(expected, convert_avro(&input, context));
+
+    context = Some(Context {
+        resolve_method: ResolveMethod::Panic,
+    });
+    assert!(std::panic::catch_unwind(|| convert_avro(&input, context)).is_err());
 }

--- a/tests/resources/array.json
+++ b/tests/resources/array.json
@@ -3,6 +3,7 @@
   "tests": [
     {
       "name": "test_array_with_atomics",
+      "compatible": true,
       "test": {
         "avro": {
           "items": {
@@ -27,6 +28,7 @@
     },
     {
       "name": "test_array_with_complex",
+      "compatible": true,
       "test": {
         "avro": {
           "items": {

--- a/tests/resources/atomic.json
+++ b/tests/resources/atomic.json
@@ -3,6 +3,7 @@
   "tests": [
     {
       "name": "test_atomic",
+      "compatible": true,
       "test": {
         "avro": {
           "type": "long"
@@ -21,6 +22,7 @@
     },
     {
       "name": "test_atomic_with_null",
+      "compatible": true,
       "test": {
         "avro": [
           {
@@ -50,6 +52,7 @@
         "Test that overlapping types are treated as json blobs."
       ],
       "name": "test_incompatible_atomic_multitype",
+      "compatible": false,
       "test": {
         "avro": {
           "type": "string"
@@ -75,6 +78,7 @@
         "A field is null if any of it's types are null."
       ],
       "name": "test_incompatible_atomic_multitype_with_null",
+      "compatible": false,
       "test": {
         "avro": [
           {
@@ -102,6 +106,7 @@
     },
     {
       "name": "test_datetime",
+      "compatible": true,
       "test": {
         "avro": {
           "type": "string"

--- a/tests/resources/map.json
+++ b/tests/resources/map.json
@@ -10,6 +10,7 @@
   "tests": [
     {
       "name": "test_map_with_atomics",
+      "compatible": true,
       "test": {
         "avro": {
           "type": "map",
@@ -46,6 +47,7 @@
     },
     {
       "name": "test_map_with_complex",
+      "compatible": true,
       "test": {
         "avro": {
           "type": "map",
@@ -130,6 +132,7 @@
     },
     {
       "name": "test_map_with_pattern_properties",
+      "compatible": true,
       "test": {
         "avro": {
           "type": "map",
@@ -169,6 +172,7 @@
     },
     {
       "name": "test_map_with_pattern_and_additional_properties",
+      "compatible": true,
       "test": {
         "avro": {
           "type": "map",
@@ -210,6 +214,7 @@
     },
     {
       "name": "test_incompatible_map_with_pattern_properties",
+      "compatible": false,
       "test": {
         "avro": {
           "type": "map",
@@ -252,6 +257,7 @@
     },
     {
       "name": "test_incompatible_map_with_pattern_and_additional_properties",
+      "compatible": false,
       "test": {
         "avro": {
           "type": "map",

--- a/tests/resources/object.json
+++ b/tests/resources/object.json
@@ -7,6 +7,7 @@
         "Sorting makes the output schema deterministic."
       ],
       "name": "test_object_with_atomics_is_sorted",
+      "compatible": true,
       "test": {
         "avro": {
           "fields": [
@@ -109,6 +110,7 @@
         "This changes the mode of the underlying atomic field."
       ],
       "name": "test_object_with_atomics_required",
+      "compatible": true,
       "test": {
         "avro": {
           "fields": [
@@ -184,6 +186,7 @@
         "Since the underlying field is null, the field is then casted back to nullable."
       ],
       "name": "test_object_with_atomics_required_with_null",
+      "compatible": true,
       "test": {
         "avro": {
           "fields": [
@@ -263,6 +266,7 @@
     },
     {
       "name": "test_object_with_complex",
+      "compatible": true,
       "test": {
         "avro": {
           "fields": [
@@ -353,6 +357,7 @@
         "as empty documents."
       ],
       "name": "test_object_empty_record",
+      "compatible": false,
       "test": {
         "avro": {
           "type": "string"

--- a/tests/resources/oneof.json
+++ b/tests/resources/oneof.json
@@ -3,6 +3,7 @@
   "tests": [
     {
       "name": "test_oneof_atomic",
+      "compatible": true,
       "test": {
         "avro": {
           "type": "long"
@@ -28,6 +29,7 @@
     },
     {
       "name": "test_oneof_atomic_with_null",
+      "compatible": true,
       "test": {
         "avro": [
           {
@@ -58,6 +60,7 @@
     },
     {
       "name": "test_incompatible_oneof_atomic",
+      "compatible": false,
       "test": {
         "avro": {
           "type": "string"
@@ -87,6 +90,7 @@
         "`null` has a logical-OR like behavior when there are choices of types."
       ],
       "name": "test_incompatible_oneof_atomic_with_null",
+      "compatible": false,
       "test": {
         "avro": [
           {
@@ -120,6 +124,7 @@
     },
     {
       "name": "test_oneof_object_with_atomics",
+      "compatible": true,
       "test": {
         "avro": {
           "fields": [
@@ -196,6 +201,7 @@
         "Test schemas that share common structure"
       ],
       "name": "test_oneof_object_merge",
+      "compatible": true,
       "test": {
         "avro": {
           "fields": [
@@ -286,6 +292,7 @@
     },
     {
       "name": "test_oneof_object_merge_with_complex",
+      "compatible": true,
       "test": {
         "avro": {
           "fields": [
@@ -454,6 +461,7 @@
     },
     {
       "name": "test_incompatible_oneof_atomic_and_object",
+      "compatible": false,
       "test": {
         "avro": {
           "type": "string"
@@ -484,6 +492,7 @@
     },
     {
       "name": "test_incompatible_oneof_object",
+      "compatible": false,
       "test": {
         "avro": {
           "type": "string"
@@ -525,6 +534,7 @@
         "retaining as much structure as possible."
       ],
       "name": "test_incompatible_oneof_object_with_complex",
+      "compatible": false,
       "test": {
         "avro": {
           "type": "string"
@@ -579,6 +589,7 @@
         "Test for nullability across two variants with required fields"
       ],
       "name": "test_oneof_object_merge_nullability",
+      "compatible": true,
       "test": {
         "avro": {
           "fields": [

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -21,7 +21,9 @@ fn avro_test_array_with_atomics() {
       "type": "array"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -81,7 +83,9 @@ fn avro_test_array_with_complex() {
       "type": "array"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -99,7 +103,9 @@ fn avro_test_atomic() {
       "type": "long"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -125,7 +131,9 @@ fn avro_test_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -146,7 +154,9 @@ fn avro_test_incompatible_atomic_multitype() {
       "type": "string"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -173,7 +183,9 @@ fn avro_test_incompatible_atomic_multitype_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -192,7 +204,9 @@ fn avro_test_datetime() {
       "type": "string"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -216,7 +230,9 @@ fn avro_test_map_with_atomics() {
       }
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -276,7 +292,9 @@ fn avro_test_map_with_complex() {
       }
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -303,7 +321,9 @@ fn avro_test_map_with_pattern_properties() {
       }
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -332,7 +352,9 @@ fn avro_test_map_with_pattern_and_additional_properties() {
       }
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -362,7 +384,9 @@ fn avro_test_incompatible_map_with_pattern_properties() {
       }
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -391,7 +415,9 @@ fn avro_test_incompatible_map_with_pattern_and_additional_properties() {
       }
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -474,7 +500,9 @@ fn avro_test_object_with_atomics_is_sorted() {
       "type": "record"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -534,7 +562,9 @@ fn avro_test_object_with_atomics_required() {
       "type": "record"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -603,7 +633,9 @@ fn avro_test_object_with_atomics_required_with_null() {
       "type": "record"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -677,7 +709,9 @@ fn avro_test_object_with_complex() {
       "type": "record"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -696,7 +730,9 @@ fn avro_test_object_empty_record() {
       "type": "string"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -721,7 +757,9 @@ fn avro_test_oneof_atomic() {
       "type": "long"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -751,7 +789,9 @@ fn avro_test_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -776,7 +816,9 @@ fn avro_test_incompatible_oneof_atomic() {
       "type": "string"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -809,7 +851,9 @@ fn avro_test_incompatible_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -877,7 +921,9 @@ fn avro_test_oneof_object_with_atomics() {
       "type": "record"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -957,7 +1003,9 @@ fn avro_test_oneof_object_merge() {
       "type": "record"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1098,7 +1146,9 @@ fn avro_test_oneof_object_merge_with_complex() {
       "type": "record"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1128,7 +1178,9 @@ fn avro_test_incompatible_oneof_atomic_and_object() {
       "type": "string"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1163,7 +1215,9 @@ fn avro_test_incompatible_oneof_object() {
       "type": "string"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1214,7 +1268,9 @@ fn avro_test_incompatible_oneof_object_with_complex() {
       "type": "string"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1294,7 +1350,9 @@ fn avro_test_oneof_object_merge_nullability() {
       "type": "record"
     }
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -1,4 +1,5 @@
 use jst::convert_avro;
+use jst::{Context, ResolveMethod};
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 
@@ -20,9 +21,12 @@ fn avro_test_array_with_atomics() {
       "type": "array"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -79,9 +83,12 @@ fn avro_test_array_with_complex() {
       "type": "array"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -96,9 +103,12 @@ fn avro_test_atomic() {
       "type": "long"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -121,9 +131,12 @@ fn avro_test_atomic_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -141,9 +154,12 @@ fn avro_test_incompatible_atomic_multitype() {
       "type": "string"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -167,9 +183,12 @@ fn avro_test_incompatible_atomic_multitype_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -185,9 +204,12 @@ fn avro_test_datetime() {
       "type": "string"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -208,9 +230,12 @@ fn avro_test_map_with_atomics() {
       }
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -267,9 +292,12 @@ fn avro_test_map_with_complex() {
       }
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -293,9 +321,12 @@ fn avro_test_map_with_pattern_properties() {
       }
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -321,9 +352,12 @@ fn avro_test_map_with_pattern_and_additional_properties() {
       }
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -350,9 +384,12 @@ fn avro_test_incompatible_map_with_pattern_properties() {
       }
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -378,9 +415,12 @@ fn avro_test_incompatible_map_with_pattern_and_additional_properties() {
       }
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -460,9 +500,12 @@ fn avro_test_object_with_atomics_is_sorted() {
       "type": "record"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -519,9 +562,12 @@ fn avro_test_object_with_atomics_required() {
       "type": "record"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -587,9 +633,12 @@ fn avro_test_object_with_atomics_required_with_null() {
       "type": "record"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -660,9 +709,12 @@ fn avro_test_object_with_complex() {
       "type": "record"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -678,9 +730,12 @@ fn avro_test_object_empty_record() {
       "type": "string"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -702,9 +757,12 @@ fn avro_test_oneof_atomic() {
       "type": "long"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -731,9 +789,12 @@ fn avro_test_oneof_atomic_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -755,9 +816,12 @@ fn avro_test_incompatible_oneof_atomic() {
       "type": "string"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -787,9 +851,12 @@ fn avro_test_incompatible_oneof_atomic_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -854,9 +921,12 @@ fn avro_test_oneof_object_with_atomics() {
       "type": "record"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -933,9 +1003,12 @@ fn avro_test_oneof_object_merge() {
       "type": "record"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -1073,9 +1146,12 @@ fn avro_test_oneof_object_merge_with_complex() {
       "type": "record"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -1102,9 +1178,12 @@ fn avro_test_incompatible_oneof_atomic_and_object() {
       "type": "string"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -1136,9 +1215,12 @@ fn avro_test_incompatible_oneof_object() {
       "type": "string"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -1186,9 +1268,12 @@ fn avro_test_incompatible_oneof_object_with_complex() {
       "type": "string"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }
 
 #[test]
@@ -1265,7 +1350,10 @@ fn avro_test_oneof_object_merge_nullability() {
       "type": "record"
     }
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, None));
+    assert_eq!(expected, convert_avro(&input, Some(context)));
 }

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -21,12 +21,15 @@ fn avro_test_array_with_atomics() {
       "type": "array"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -83,12 +86,15 @@ fn avro_test_array_with_complex() {
       "type": "array"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -103,12 +109,15 @@ fn avro_test_atomic() {
       "type": "long"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -131,15 +140,19 @@ fn avro_test_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_atomic_multitype() {
     let input_data = r#"
     {
@@ -154,15 +167,19 @@ fn avro_test_incompatible_atomic_multitype() {
       "type": "string"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_atomic_multitype_with_null() {
     let input_data = r#"
     {
@@ -183,12 +200,15 @@ fn avro_test_incompatible_atomic_multitype_with_null() {
       }
     ]
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -204,12 +224,15 @@ fn avro_test_datetime() {
       "type": "string"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -230,12 +253,15 @@ fn avro_test_map_with_atomics() {
       }
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -292,12 +318,15 @@ fn avro_test_map_with_complex() {
       }
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -321,12 +350,15 @@ fn avro_test_map_with_pattern_properties() {
       }
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -352,15 +384,19 @@ fn avro_test_map_with_pattern_and_additional_properties() {
       }
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_map_with_pattern_properties() {
     let input_data = r#"
     {
@@ -384,15 +420,19 @@ fn avro_test_incompatible_map_with_pattern_properties() {
       }
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_map_with_pattern_and_additional_properties() {
     let input_data = r#"
     {
@@ -415,12 +455,15 @@ fn avro_test_incompatible_map_with_pattern_and_additional_properties() {
       }
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -500,12 +543,15 @@ fn avro_test_object_with_atomics_is_sorted() {
       "type": "record"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -562,12 +608,15 @@ fn avro_test_object_with_atomics_required() {
       "type": "record"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -633,12 +682,15 @@ fn avro_test_object_with_atomics_required_with_null() {
       "type": "record"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -709,15 +761,19 @@ fn avro_test_object_with_complex() {
       "type": "record"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_object_empty_record() {
     let input_data = r#"
     {
@@ -730,12 +786,15 @@ fn avro_test_object_empty_record() {
       "type": "string"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -757,12 +816,15 @@ fn avro_test_oneof_atomic() {
       "type": "long"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -789,15 +851,19 @@ fn avro_test_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_oneof_atomic() {
     let input_data = r#"
     {
@@ -816,15 +882,19 @@ fn avro_test_incompatible_oneof_atomic() {
       "type": "string"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_oneof_atomic_with_null() {
     let input_data = r#"
     {
@@ -851,12 +921,15 @@ fn avro_test_incompatible_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -921,12 +994,15 @@ fn avro_test_oneof_object_with_atomics() {
       "type": "record"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -1003,12 +1079,15 @@ fn avro_test_oneof_object_merge() {
       "type": "record"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -1146,15 +1225,19 @@ fn avro_test_oneof_object_merge_with_complex() {
       "type": "record"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_oneof_atomic_and_object() {
     let input_data = r#"
     {
@@ -1178,15 +1261,19 @@ fn avro_test_incompatible_oneof_atomic_and_object() {
       "type": "string"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_oneof_object() {
     let input_data = r#"
     {
@@ -1215,15 +1302,19 @@ fn avro_test_incompatible_oneof_object() {
       "type": "string"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
+#[should_panic]
 fn avro_test_incompatible_oneof_object_with_complex() {
     let input_data = r#"
     {
@@ -1268,12 +1359,15 @@ fn avro_test_incompatible_oneof_object_with_complex() {
       "type": "string"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }
 
 #[test]
@@ -1350,10 +1444,13 @@ fn avro_test_oneof_object_merge_nullability() {
       "type": "record"
     }
     "#;
-    let context = Context {
+    let mut context = Context {
         resolve_method: ResolveMethod::Cast,
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
 }

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -26,7 +26,7 @@ fn avro_test_array_with_atomics() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn avro_test_array_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -108,7 +108,7 @@ fn avro_test_atomic() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -136,7 +136,7 @@ fn avro_test_atomic_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn avro_test_incompatible_atomic_multitype() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn avro_test_incompatible_atomic_multitype_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -209,7 +209,7 @@ fn avro_test_datetime() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -235,7 +235,7 @@ fn avro_test_map_with_atomics() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -297,7 +297,7 @@ fn avro_test_map_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -326,7 +326,7 @@ fn avro_test_map_with_pattern_properties() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn avro_test_map_with_pattern_and_additional_properties() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -389,7 +389,7 @@ fn avro_test_incompatible_map_with_pattern_properties() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -420,7 +420,7 @@ fn avro_test_incompatible_map_with_pattern_and_additional_properties() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -505,7 +505,7 @@ fn avro_test_object_with_atomics_is_sorted() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -567,7 +567,7 @@ fn avro_test_object_with_atomics_required() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -638,7 +638,7 @@ fn avro_test_object_with_atomics_required_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -714,7 +714,7 @@ fn avro_test_object_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -735,7 +735,7 @@ fn avro_test_object_empty_record() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -762,7 +762,7 @@ fn avro_test_oneof_atomic() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -794,7 +794,7 @@ fn avro_test_oneof_atomic_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -821,7 +821,7 @@ fn avro_test_incompatible_oneof_atomic() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -856,7 +856,7 @@ fn avro_test_incompatible_oneof_atomic_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -926,7 +926,7 @@ fn avro_test_oneof_object_with_atomics() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -1008,7 +1008,7 @@ fn avro_test_oneof_object_merge() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -1151,7 +1151,7 @@ fn avro_test_oneof_object_merge_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -1183,7 +1183,7 @@ fn avro_test_incompatible_oneof_atomic_and_object() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -1220,7 +1220,7 @@ fn avro_test_incompatible_oneof_object() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -1273,7 +1273,7 @@ fn avro_test_incompatible_oneof_object_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }
 
 #[test]
@@ -1355,5 +1355,5 @@ fn avro_test_oneof_object_merge_nullability() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input, Some(context)));
+    assert_eq!(expected, convert_avro(&input, context));
 }

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -22,7 +22,7 @@ fn avro_test_array_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn avro_test_array_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn avro_test_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn avro_test_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn avro_test_incompatible_atomic_multitype() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -169,7 +169,7 @@ fn avro_test_incompatible_atomic_multitype_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -187,7 +187,7 @@ fn avro_test_datetime() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn avro_test_map_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -269,7 +269,7 @@ fn avro_test_map_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn avro_test_map_with_pattern_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -323,7 +323,7 @@ fn avro_test_map_with_pattern_and_additional_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -352,7 +352,7 @@ fn avro_test_incompatible_map_with_pattern_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -380,7 +380,7 @@ fn avro_test_incompatible_map_with_pattern_and_additional_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -462,7 +462,7 @@ fn avro_test_object_with_atomics_is_sorted() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -521,7 +521,7 @@ fn avro_test_object_with_atomics_required() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -589,7 +589,7 @@ fn avro_test_object_with_atomics_required_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -662,7 +662,7 @@ fn avro_test_object_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -680,7 +680,7 @@ fn avro_test_object_empty_record() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -704,7 +704,7 @@ fn avro_test_oneof_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -733,7 +733,7 @@ fn avro_test_oneof_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -757,7 +757,7 @@ fn avro_test_incompatible_oneof_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -789,7 +789,7 @@ fn avro_test_incompatible_oneof_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -856,7 +856,7 @@ fn avro_test_oneof_object_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -935,7 +935,7 @@ fn avro_test_oneof_object_merge() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -1075,7 +1075,7 @@ fn avro_test_oneof_object_merge_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -1104,7 +1104,7 @@ fn avro_test_incompatible_oneof_atomic_and_object() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -1138,7 +1138,7 @@ fn avro_test_incompatible_oneof_object() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -1188,7 +1188,7 @@ fn avro_test_incompatible_oneof_object_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }
 
 #[test]
@@ -1267,5 +1267,5 @@ fn avro_test_oneof_object_merge_nullability() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_avro(&input));
+    assert_eq!(expected, convert_avro(&input, None));
 }

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -21,9 +21,7 @@ fn avro_test_array_with_atomics() {
       "type": "array"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -83,9 +81,7 @@ fn avro_test_array_with_complex() {
       "type": "array"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -103,9 +99,7 @@ fn avro_test_atomic() {
       "type": "long"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -131,9 +125,7 @@ fn avro_test_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -154,9 +146,7 @@ fn avro_test_incompatible_atomic_multitype() {
       "type": "string"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -183,9 +173,7 @@ fn avro_test_incompatible_atomic_multitype_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -204,9 +192,7 @@ fn avro_test_datetime() {
       "type": "string"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -230,9 +216,7 @@ fn avro_test_map_with_atomics() {
       }
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -292,9 +276,7 @@ fn avro_test_map_with_complex() {
       }
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -321,9 +303,7 @@ fn avro_test_map_with_pattern_properties() {
       }
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -352,9 +332,7 @@ fn avro_test_map_with_pattern_and_additional_properties() {
       }
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -384,9 +362,7 @@ fn avro_test_incompatible_map_with_pattern_properties() {
       }
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -415,9 +391,7 @@ fn avro_test_incompatible_map_with_pattern_and_additional_properties() {
       }
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -500,9 +474,7 @@ fn avro_test_object_with_atomics_is_sorted() {
       "type": "record"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -562,9 +534,7 @@ fn avro_test_object_with_atomics_required() {
       "type": "record"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -633,9 +603,7 @@ fn avro_test_object_with_atomics_required_with_null() {
       "type": "record"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -709,9 +677,7 @@ fn avro_test_object_with_complex() {
       "type": "record"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -730,9 +696,7 @@ fn avro_test_object_empty_record() {
       "type": "string"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -757,9 +721,7 @@ fn avro_test_oneof_atomic() {
       "type": "long"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -789,9 +751,7 @@ fn avro_test_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -816,9 +776,7 @@ fn avro_test_incompatible_oneof_atomic() {
       "type": "string"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -851,9 +809,7 @@ fn avro_test_incompatible_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -921,9 +877,7 @@ fn avro_test_oneof_object_with_atomics() {
       "type": "record"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1003,9 +957,7 @@ fn avro_test_oneof_object_merge() {
       "type": "record"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1146,9 +1098,7 @@ fn avro_test_oneof_object_merge_with_complex() {
       "type": "record"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1178,9 +1128,7 @@ fn avro_test_incompatible_oneof_atomic_and_object() {
       "type": "string"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1215,9 +1163,7 @@ fn avro_test_incompatible_oneof_object() {
       "type": "string"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1268,9 +1214,7 @@ fn avro_test_incompatible_oneof_object_with_complex() {
       "type": "string"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));
@@ -1350,9 +1294,7 @@ fn avro_test_oneof_object_merge_nullability() {
       "type": "record"
     }
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_avro(&input, Some(context)));

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -1,4 +1,5 @@
 use jst::convert_bigquery;
+use jst::{Context, ResolveMethod};
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 
@@ -21,9 +22,12 @@ fn bigquery_test_array_with_atomics() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -65,9 +69,12 @@ fn bigquery_test_array_with_complex() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -86,9 +93,12 @@ fn bigquery_test_atomic() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -110,9 +120,12 @@ fn bigquery_test_atomic_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -134,9 +147,12 @@ fn bigquery_test_incompatible_atomic_multitype() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -159,9 +175,12 @@ fn bigquery_test_incompatible_atomic_multitype_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -181,9 +200,12 @@ fn bigquery_test_datetime() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -217,9 +239,12 @@ fn bigquery_test_map_with_atomics() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -273,9 +298,12 @@ fn bigquery_test_map_with_complex() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -312,9 +340,12 @@ fn bigquery_test_map_with_pattern_properties() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -353,9 +384,12 @@ fn bigquery_test_map_with_pattern_and_additional_properties() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -395,9 +429,12 @@ fn bigquery_test_incompatible_map_with_pattern_properties() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -436,9 +473,12 @@ fn bigquery_test_incompatible_map_with_pattern_and_additional_properties() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -486,9 +526,12 @@ fn bigquery_test_object_with_atomics_is_sorted() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -532,9 +575,12 @@ fn bigquery_test_object_with_atomics_required() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -581,9 +627,12 @@ fn bigquery_test_object_with_atomics_required_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -627,9 +676,12 @@ fn bigquery_test_object_with_complex() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -649,9 +701,12 @@ fn bigquery_test_object_empty_record() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -677,9 +732,12 @@ fn bigquery_test_oneof_atomic() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -705,9 +763,12 @@ fn bigquery_test_oneof_atomic_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -733,9 +794,12 @@ fn bigquery_test_incompatible_oneof_atomic() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -764,9 +828,12 @@ fn bigquery_test_incompatible_oneof_atomic_with_null() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -813,9 +880,12 @@ fn bigquery_test_oneof_object_with_atomics() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -867,9 +937,12 @@ fn bigquery_test_oneof_object_merge() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -959,9 +1032,12 @@ fn bigquery_test_oneof_object_merge_with_complex() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -992,9 +1068,12 @@ fn bigquery_test_incompatible_oneof_atomic_and_object() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -1030,9 +1109,12 @@ fn bigquery_test_incompatible_oneof_object() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -1084,9 +1166,12 @@ fn bigquery_test_incompatible_oneof_object_with_complex() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }
 
 #[test]
@@ -1144,7 +1229,10 @@ fn bigquery_test_oneof_object_merge_nullability() {
       }
     ]
     "#;
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, None));
+    assert_eq!(expected, convert_bigquery(&input, Some(context)));
 }

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -22,9 +22,7 @@ fn bigquery_test_array_with_atomics() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -69,9 +67,7 @@ fn bigquery_test_array_with_complex() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -93,9 +89,7 @@ fn bigquery_test_atomic() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -120,9 +114,7 @@ fn bigquery_test_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -147,9 +139,7 @@ fn bigquery_test_incompatible_atomic_multitype() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -175,9 +165,7 @@ fn bigquery_test_incompatible_atomic_multitype_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -200,9 +188,7 @@ fn bigquery_test_datetime() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -239,9 +225,7 @@ fn bigquery_test_map_with_atomics() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -298,9 +282,7 @@ fn bigquery_test_map_with_complex() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -340,9 +322,7 @@ fn bigquery_test_map_with_pattern_properties() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -384,9 +364,7 @@ fn bigquery_test_map_with_pattern_and_additional_properties() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -429,9 +407,7 @@ fn bigquery_test_incompatible_map_with_pattern_properties() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -473,9 +449,7 @@ fn bigquery_test_incompatible_map_with_pattern_and_additional_properties() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -526,9 +500,7 @@ fn bigquery_test_object_with_atomics_is_sorted() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -575,9 +547,7 @@ fn bigquery_test_object_with_atomics_required() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -627,9 +597,7 @@ fn bigquery_test_object_with_atomics_required_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -676,9 +644,7 @@ fn bigquery_test_object_with_complex() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -701,9 +667,7 @@ fn bigquery_test_object_empty_record() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -732,9 +696,7 @@ fn bigquery_test_oneof_atomic() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -763,9 +725,7 @@ fn bigquery_test_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -794,9 +754,7 @@ fn bigquery_test_incompatible_oneof_atomic() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -828,9 +786,7 @@ fn bigquery_test_incompatible_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -880,9 +836,7 @@ fn bigquery_test_oneof_object_with_atomics() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -937,9 +891,7 @@ fn bigquery_test_oneof_object_merge() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1032,9 +984,7 @@ fn bigquery_test_oneof_object_merge_with_complex() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1068,9 +1018,7 @@ fn bigquery_test_incompatible_oneof_atomic_and_object() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1109,9 +1057,7 @@ fn bigquery_test_incompatible_oneof_object() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1166,9 +1112,7 @@ fn bigquery_test_incompatible_oneof_object_with_complex() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1229,9 +1173,7 @@ fn bigquery_test_oneof_object_merge_nullability() {
       }
     ]
     "#;
-    let context = Context {
-        resolve_method: ResolveMethod::Cast,
-    };
+    let context = Context { resolve_method: ResolveMethod::Cast };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -22,7 +22,9 @@ fn bigquery_test_array_with_atomics() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -67,7 +69,9 @@ fn bigquery_test_array_with_complex() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -89,7 +93,9 @@ fn bigquery_test_atomic() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -114,7 +120,9 @@ fn bigquery_test_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -139,7 +147,9 @@ fn bigquery_test_incompatible_atomic_multitype() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -165,7 +175,9 @@ fn bigquery_test_incompatible_atomic_multitype_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -188,7 +200,9 @@ fn bigquery_test_datetime() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -225,7 +239,9 @@ fn bigquery_test_map_with_atomics() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -282,7 +298,9 @@ fn bigquery_test_map_with_complex() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -322,7 +340,9 @@ fn bigquery_test_map_with_pattern_properties() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -364,7 +384,9 @@ fn bigquery_test_map_with_pattern_and_additional_properties() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -407,7 +429,9 @@ fn bigquery_test_incompatible_map_with_pattern_properties() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -449,7 +473,9 @@ fn bigquery_test_incompatible_map_with_pattern_and_additional_properties() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -500,7 +526,9 @@ fn bigquery_test_object_with_atomics_is_sorted() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -547,7 +575,9 @@ fn bigquery_test_object_with_atomics_required() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -597,7 +627,9 @@ fn bigquery_test_object_with_atomics_required_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -644,7 +676,9 @@ fn bigquery_test_object_with_complex() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -667,7 +701,9 @@ fn bigquery_test_object_empty_record() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -696,7 +732,9 @@ fn bigquery_test_oneof_atomic() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -725,7 +763,9 @@ fn bigquery_test_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -754,7 +794,9 @@ fn bigquery_test_incompatible_oneof_atomic() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -786,7 +828,9 @@ fn bigquery_test_incompatible_oneof_atomic_with_null() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -836,7 +880,9 @@ fn bigquery_test_oneof_object_with_atomics() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -891,7 +937,9 @@ fn bigquery_test_oneof_object_merge() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -984,7 +1032,9 @@ fn bigquery_test_oneof_object_merge_with_complex() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1018,7 +1068,9 @@ fn bigquery_test_incompatible_oneof_atomic_and_object() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1057,7 +1109,9 @@ fn bigquery_test_incompatible_oneof_object() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1112,7 +1166,9 @@ fn bigquery_test_incompatible_oneof_object_with_complex() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));
@@ -1173,7 +1229,9 @@ fn bigquery_test_oneof_object_merge_nullability() {
       }
     ]
     "#;
-    let context = Context { resolve_method: ResolveMethod::Cast };
+    let context = Context {
+        resolve_method: ResolveMethod::Cast,
+    };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
     assert_eq!(expected, convert_bigquery(&input, Some(context)));

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -23,7 +23,7 @@ fn bigquery_test_array_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn bigquery_test_array_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn bigquery_test_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -112,7 +112,7 @@ fn bigquery_test_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -136,7 +136,7 @@ fn bigquery_test_incompatible_atomic_multitype() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn bigquery_test_incompatible_atomic_multitype_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -183,7 +183,7 @@ fn bigquery_test_datetime() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -219,7 +219,7 @@ fn bigquery_test_map_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -275,7 +275,7 @@ fn bigquery_test_map_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -314,7 +314,7 @@ fn bigquery_test_map_with_pattern_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -355,7 +355,7 @@ fn bigquery_test_map_with_pattern_and_additional_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -397,7 +397,7 @@ fn bigquery_test_incompatible_map_with_pattern_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -438,7 +438,7 @@ fn bigquery_test_incompatible_map_with_pattern_and_additional_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -488,7 +488,7 @@ fn bigquery_test_object_with_atomics_is_sorted() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -534,7 +534,7 @@ fn bigquery_test_object_with_atomics_required() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -583,7 +583,7 @@ fn bigquery_test_object_with_atomics_required_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -629,7 +629,7 @@ fn bigquery_test_object_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -651,7 +651,7 @@ fn bigquery_test_object_empty_record() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -679,7 +679,7 @@ fn bigquery_test_oneof_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -707,7 +707,7 @@ fn bigquery_test_oneof_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -735,7 +735,7 @@ fn bigquery_test_incompatible_oneof_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -766,7 +766,7 @@ fn bigquery_test_incompatible_oneof_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -815,7 +815,7 @@ fn bigquery_test_oneof_object_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -869,7 +869,7 @@ fn bigquery_test_oneof_object_merge() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -961,7 +961,7 @@ fn bigquery_test_oneof_object_merge_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -994,7 +994,7 @@ fn bigquery_test_incompatible_oneof_atomic_and_object() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -1032,7 +1032,7 @@ fn bigquery_test_incompatible_oneof_object() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -1086,7 +1086,7 @@ fn bigquery_test_incompatible_oneof_object_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }
 
 #[test]
@@ -1146,5 +1146,5 @@ fn bigquery_test_oneof_object_merge_nullability() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input));
+    assert_eq!(expected, convert_bigquery(&input, None));
 }

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -27,7 +27,7 @@ fn bigquery_test_array_with_atomics() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn bigquery_test_array_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn bigquery_test_atomic() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn bigquery_test_atomic_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn bigquery_test_incompatible_atomic_multitype() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn bigquery_test_incompatible_atomic_multitype_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -205,7 +205,7 @@ fn bigquery_test_datetime() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -244,7 +244,7 @@ fn bigquery_test_map_with_atomics() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -303,7 +303,7 @@ fn bigquery_test_map_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -345,7 +345,7 @@ fn bigquery_test_map_with_pattern_properties() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -389,7 +389,7 @@ fn bigquery_test_map_with_pattern_and_additional_properties() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -434,7 +434,7 @@ fn bigquery_test_incompatible_map_with_pattern_properties() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -478,7 +478,7 @@ fn bigquery_test_incompatible_map_with_pattern_and_additional_properties() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -531,7 +531,7 @@ fn bigquery_test_object_with_atomics_is_sorted() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -580,7 +580,7 @@ fn bigquery_test_object_with_atomics_required() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -632,7 +632,7 @@ fn bigquery_test_object_with_atomics_required_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -681,7 +681,7 @@ fn bigquery_test_object_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -706,7 +706,7 @@ fn bigquery_test_object_empty_record() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -737,7 +737,7 @@ fn bigquery_test_oneof_atomic() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -768,7 +768,7 @@ fn bigquery_test_oneof_atomic_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -799,7 +799,7 @@ fn bigquery_test_incompatible_oneof_atomic() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -833,7 +833,7 @@ fn bigquery_test_incompatible_oneof_atomic_with_null() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -885,7 +885,7 @@ fn bigquery_test_oneof_object_with_atomics() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -942,7 +942,7 @@ fn bigquery_test_oneof_object_merge() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -1037,7 +1037,7 @@ fn bigquery_test_oneof_object_merge_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -1073,7 +1073,7 @@ fn bigquery_test_incompatible_oneof_atomic_and_object() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -1114,7 +1114,7 @@ fn bigquery_test_incompatible_oneof_object() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -1171,7 +1171,7 @@ fn bigquery_test_incompatible_oneof_object_with_complex() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }
 
 #[test]
@@ -1234,5 +1234,5 @@ fn bigquery_test_oneof_object_merge_nullability() {
     };
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery(&input, Some(context)));
+    assert_eq!(expected, convert_bigquery(&input, context));
 }


### PR DESCRIPTION
This PR should (mostly) fix #75.

The approach in this pull-request is as follows:

* [x] Create a new trait that replaces `From` and `Into` with something akin to `TryFrom` and `TryInto` which includes a Result type. This new trait is named `Translate`. 
* [x] Add a new Context structure for passing flags from the command line into the `Translate` trait (requires modifying the trait definition).
* [x] Modify bigquery.rs to drop, cast, or panic
* [x] Modify avro.rs to drop, cast, or panic
* [x] Add unit tests where appropriate

---

At a high-level, we should be dropping fields during transpilation if the subschema is incompatible (tuple validation) or if the schema is underspecified (an empty object). This adds error-handling when translating between schemas (`ast -> bigquery` and `ast -> avro` in particular).

I've tried to keep the changes minimal. I've left most of the unit-tests alone aside from refactoring so it is easier to add the context variable. I've added a `compatible` field to the `TestCase` object which makes it easy to retrofit the existing tests to determine whether fields will be dropped with the new error handling methods.

See https://github.com/mozilla/jsonschema-transpiler/pull/76#issuecomment-505630943 for a sanity check on the full schema repository. 