### PR TITLE
Remove redundant code path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jsonschema-transpiler"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonschema-transpiler"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Anthony Miyaguchi <amiyaguchi@mozilla.com>"]
 description = "A tool to transpile JSON Schema into schemas for data processing"
 license = "MPL-2.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -531,12 +531,7 @@ impl Tag {
                     item.infer_nullability(force_nullable);
                 }
             }
-            _ => {
-                // Other types, like atoms, are set to nullable if enforced
-                if force_nullable {
-                    self.nullable = true;
-                }
-            }
+            _ => (),
         }
         if force_nullable {
             self.nullable = true


### PR DESCRIPTION
> I don't understand why this is setting `self.nullable = true` both here and on 537

_Originally posted by @relud in https://github.com/mozilla/jsonschema-transpiler/pull/85_

Thanks for pushing on this one, it's certainly a redundant path. I should have spent more time looking it over. 