### PR TITLE
Nested list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -125,6 +126,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
@@ -394,6 +400,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a646989adad8a19f49be2090374712931c3a59835cb5277b4530f48b417f26e7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ onig = "4.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.3.0"
+maplit = "1.0.2"
 
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/scripts/mps-generate-avro-data-helper.py
+++ b/scripts/mps-generate-avro-data-helper.py
@@ -44,6 +44,10 @@ def convert(data, schema):
         out = {}
         if not data:
             return out
+
+        # convert a nested
+        if isinstance(data, list) and set(schema.field_map.keys()) == {"list"}:
+            data = {"list": data}
         # cast tuple into an object before continuing
         if isinstance(data, list):
             data = {f"f{i}_": v for i, v in enumerate(data)}

--- a/scripts/mps-generate-avro-data-helper.py
+++ b/scripts/mps-generate-avro-data-helper.py
@@ -34,7 +34,6 @@ def format_key(key):
 
 
 def convert(data, schema):
-
     if schema.type == "string":
         if not isinstance(data, str):
             return json.dumps(data)
@@ -100,13 +99,14 @@ with open(f"data/{document}.ndjson", "r") as f:
     data = f.readlines()
 
 try:
-    out = {}
+    orig = None
     for line in data:
-        out = convert(json.loads(line), schema)
+        orig = json.loads(line)
+        out = convert(orig, schema)
         writer.append(out)
 except:
     with open("test.json", "w") as f:
-        json.dump(out, f)
+        json.dump(orig, f)
     with open("test-schema.json", "w") as f:
         json.dump(schema.to_json(), f, indent=2)
     validation.validate(out, parse_schema(schema.to_json()))

--- a/scripts/mps-verify-nested-list.sh
+++ b/scripts/mps-verify-nested-list.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+cd "$(dirname "$0").."
+
+datadir=$(mktemp -d -t tmp.XXXXXXXXXX)
+function cleanup {
+    echo "Running cleanup!"
+    rm -rf "$datadir"
+}
+trap cleanup EXIT
+
+scripts/mps-download-schemas.sh
+
+avro_no_tuple_control=$datadir/avro-no-tuple-control
+avro_tuple_control=$datadir/avro-tuple-control
+avro_no_tuple=$datadir/avro-no-tuple
+avro_tuple=$datadir/avro-tuple
+
+bq_no_tuple_control=$datadir/bq-no-tuple-control
+bq_tuple_control=$datadir/bq-tuple-control
+bq_no_tuple=$datadir/bq-no-tuple
+bq_tuple=$datadir/bq-tuple
+
+
+# get control values
+git checkout v1.5.0
+
+scripts/mps-generate-schemas.sh $avro_no_tuple_control --type avro --resolve drop
+scripts/mps-generate-schemas.sh $avro_tuple_control --type avro --resolve drop --tuple-struct
+scripts/mps-generate-schemas.sh $bq_no_tuple_control --type bigquery --resolve drop
+scripts/mps-generate-schemas.sh $bq_tuple_control --type bigquery --resolve drop --tuple-struct
+
+git checkout -
+
+# get values for tuple/no-tuple
+scripts/mps-generate-schemas.sh $avro_no_tuple --type avro --resolve drop
+scripts/mps-generate-schemas.sh $avro_tuple --type avro --resolve drop --tuple-struct
+scripts/mps-generate-schemas.sh $bq_no_tuple --type bigquery --resolve drop
+scripts/mps-generate-schemas.sh $bq_tuple --type bigquery --resolve drop --tuple-struct
+
+outdir="test_nested_list_results"
+mkdir -p $outdir
+
+diff -r $avro_no_tuple_control $avro_no_tuple > $outdir/avro-no-tuple.diff
+diff -r $avro_tuple_control $avro_tuple > $outdir/avro-tuple.diff
+diff -r $bq_no_tuple_control $bq_no_tuple > $outdir/bq-no-tuple.diff
+diff -r $bq_tuple_control $bq_tuple > $outdir/bq-tuple.diff

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -471,7 +471,7 @@ impl Tag {
                 set_and_recurse(&mut map.value, "value");
             }
             Type::Array(array) => {
-                set_and_recurse(&mut array.items, "items");
+                set_and_recurse(&mut array.items, "list");
             }
             Type::Union(union) => {
                 for item in union.items.iter_mut() {
@@ -1058,7 +1058,7 @@ mod tests {
                 "items": {
                     "nullable": false,
                     // array items are always named item, for the sanity of avro
-                    "name": "items",
+                    "name": "list",
                     "namespace": "foo",
                     "type": {
                         "object": {
@@ -1066,7 +1066,7 @@ mod tests {
                                 "bar": {
                                     "nullable": false,
                                     "name": "bar",
-                                    "namespace": "foo.items",
+                                    "namespace": "foo.list",
                                     "type": {"atom": "integer"}}
                             }}}}}}});
         assert_infer_name(expect, data);

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -242,7 +242,9 @@ impl TranslateFrom<ast::Tag> for Type {
                                 },
                                 fields: vec![Field {
                                     name: "list".into(),
-                                    data_type: data_type,
+                                    data_type: Type::Complex(Complex::Array(Array {
+                                        items: Box::new(data_type),
+                                    })),
                                     ..Default::default()
                                 }],
                             }))
@@ -657,7 +659,10 @@ mod tests {
                     "type": {
                         "type": "array",
                         "items": {
-                            "type": "long"
+                            "type": "array",
+                            "items": {
+                                "type": "long"
+                            }
                         }
                     }
                 }

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -115,6 +115,7 @@ impl TranslateFrom<ast::Tag> for Type {
             // construction of the namespace. Fully qualified names require a
             // top-down approach.
             tag.collapse();
+            tag.expand_nested_arrays(false);
             tag.name = Some("root".into());
             tag.infer_name(context.normalize_case);
         }

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -246,9 +246,7 @@ impl TranslateFrom<ast::Tag> for Type {
                                     },
                                     fields: vec![Field {
                                         name: "list".into(),
-                                        data_type: Type::Complex(Complex::Array(Array {
-                                            items: Box::new(data_type),
-                                        })),
+                                        data_type,
                                         ..Default::default()
                                     }],
                                 }))),
@@ -667,10 +665,7 @@ mod tests {
                             "type": {
                                 "type": "array",
                                 "items": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "long"
-                                    }
+                                    "type": "long"
                                 }
                             }
                         }

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -621,16 +621,17 @@ mod tests {
     #[test]
     fn from_ast_array_array() {
         let ast = json!({
+            "is_root": true,
             "type": {"array": {"items": {
                 "type": {"array": {"items":
                     {"type": {"atom": "integer"}}}}}}}
         });
         let avro = json!({
             "type": "record",
-            "name": "items",
+            "name": "root",
             "fields": [
                 {
-                    "name": "items",
+                    "name": "list",
                     "type": {
                         "type": "array",
                         "items": {

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -115,7 +115,6 @@ impl TranslateFrom<ast::Tag> for Type {
             // construction of the namespace. Fully qualified names require a
             // top-down approach.
             tag.collapse();
-            tag.expand_nested_arrays(false);
             tag.name = Some("root".into());
             tag.infer_name(context.normalize_case);
         }

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -618,6 +618,31 @@ mod tests {
     }
 
     #[test]
+    fn from_ast_array_array() {
+        let ast = json!({
+            "type": {"array": {"items": {
+                "type": {"array": {"items":
+                    {"type": {"atom": "integer"}}}}}}}
+        });
+        let avro = json!({
+            "type": "record",
+            "name": "items",
+            "fields": [
+                {
+                    "name": "items",
+                    "type": {
+                        "type": "array",
+                        "items": {
+                            "type": "long"
+                        }
+                    }
+                }
+            ]
+        });
+        assert_from_ast_eq(ast, avro);
+    }
+
+    #[test]
     fn from_ast_tuple() {
         // This case is not handled and instead converted into an object
         let ast = json!({

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -234,19 +234,24 @@ impl TranslateFrom<ast::Tag> for Type {
                 match Type::translate_from(*array.items.clone(), context) {
                     Ok(data_type) => {
                         if child_is_array {
-                            Type::Complex(Complex::Record(Record {
-                                common: CommonAttributes {
-                                    name: tag.name.clone().unwrap_or_else(|| "__UNNAMED__".into()),
-                                    namespace: tag.namespace.clone(),
-                                    ..Default::default()
-                                },
-                                fields: vec![Field {
-                                    name: "list".into(),
-                                    data_type: Type::Complex(Complex::Array(Array {
-                                        items: Box::new(data_type),
-                                    })),
-                                    ..Default::default()
-                                }],
+                            Type::Complex(Complex::Array(Array {
+                                items: Box::new(Type::Complex(Complex::Record(Record {
+                                    common: CommonAttributes {
+                                        name: tag
+                                            .name
+                                            .clone()
+                                            .unwrap_or_else(|| "__UNNAMED__".into()),
+                                        namespace: tag.namespace.clone(),
+                                        ..Default::default()
+                                    },
+                                    fields: vec![Field {
+                                        name: "list".into(),
+                                        data_type: Type::Complex(Complex::Array(Array {
+                                            items: Box::new(data_type),
+                                        })),
+                                        ..Default::default()
+                                    }],
+                                }))),
                             }))
                         } else {
                             Type::Complex(Complex::Array(Array {
@@ -651,22 +656,26 @@ mod tests {
                     {"type": {"atom": "integer"}}}}}}}
         });
         let avro = json!({
-            "type": "record",
-            "name": "root",
-            "fields": [
+            "type": "array",
+            "items":
                 {
-                    "name": "list",
-                    "type": {
-                        "type": "array",
-                        "items": {
-                            "type": "array",
-                            "items": {
-                                "type": "long"
+                    "type": "record",
+                    "name": "root",
+                    "fields": [
+                        {
+                            "name": "list",
+                            "type": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "long"
+                                    }
+                                }
                             }
                         }
-                    }
+                    ]
                 }
-            ]
         });
         assert_from_ast_eq(ast, avro);
     }

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -133,10 +133,24 @@ impl TranslateFrom<ast::Tag> for Tag {
                     fields: named_fields,
                 })
             }
-            ast::Type::Array(array) => match Tag::translate_from(*array.items.clone(), context) {
-                Ok(tag) => *tag.data_type,
-                Err(_) => return Err(fmt_reason("untyped array")),
-            },
+            ast::Type::Array(array) => {
+                // workaround for nested lists
+                let child_is_array = match &array.items.data_type {
+                    ast::Type::Array(_) => true,
+                    _ => false,
+                };
+                let sub_tag = match Tag::translate_from(*array.items.clone(), context) {
+                    Ok(tag) => tag,
+                    Err(_) => return Err(fmt_reason("untyped array")),
+                };
+                if child_is_array {
+                    Type::Record(Record {
+                        fields: hashmap! {"list".into() => Box::new(sub_tag)},
+                    })
+                } else {
+                    *sub_tag.data_type
+                }
+            }
             ast::Type::Map(map) => {
                 let key = Tag::translate_from(*map.key.clone(), context).unwrap();
                 let value = match Tag::translate_from(*map.value.clone(), context) {

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -183,7 +183,9 @@ impl TranslateFrom<ast::Tag> for Schema {
     type Error = &'static str;
 
     fn translate_from(tag: ast::Tag, context: Context) -> Result<Self, Self::Error> {
-        let mut bq_tag = Tag::translate_from(tag.clone(), context).unwrap();
+        let mut cloned = tag.clone();
+        cloned.expand_nested_arrays(tag.is_array());
+        let mut bq_tag = Tag::translate_from(cloned, context).unwrap();
         match *bq_tag.data_type {
             // Maps and arrays are both treated as a Record type with different
             // modes. These should not be extracted if they are the root-type.

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -183,9 +183,7 @@ impl TranslateFrom<ast::Tag> for Schema {
     type Error = &'static str;
 
     fn translate_from(tag: ast::Tag, context: Context) -> Result<Self, Self::Error> {
-        let mut cloned = tag.clone();
-        cloned.expand_nested_arrays(tag.is_array());
-        let mut bq_tag = Tag::translate_from(cloned, context).unwrap();
+        let mut bq_tag = Tag::translate_from(tag.clone(), context).unwrap();
         match *bq_tag.data_type {
             // Maps and arrays are both treated as a Record type with different
             // modes. These should not be extracted if they are the root-type.

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -542,6 +542,28 @@ mod tests {
     }
 
     #[test]
+    fn from_bigquery_array_array() {
+        let data = json!({
+            "type": {"array": {"items": {
+                "type": {"array": {"items":
+                    {"type": {"atom": "integer"}}}}}}}
+        });
+        let expect = json!({
+            "name": "root",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+                {
+                    "name": "items",
+                    "type": "INT64",
+                    "mode": "REPEATED"
+                }
+            ]
+        });
+        assert_eq!(expect, transform_tag(data));
+    }
+
+    #[test]
     fn test_from_ast_tuple() {
         let data = json!({
             "type": {

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -551,12 +551,11 @@ mod tests {
                     {"type": {"atom": "integer"}}}}}}}
         });
         let expect = json!({
-            "name": "root",
             "type": "RECORD",
             "mode": "REPEATED",
             "fields": [
                 {
-                    "name": "items",
+                    "name": "list",
                     "type": "INT64",
                     "mode": "REPEATED"
                 }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -251,10 +251,10 @@ impl Tag {
                                     .collect();
                                 let mut unwrapped = items?;
                                 let min_items: usize =
-                                    self.array.min_items.unwrap_or(unwrapped.len());
+                                    self.array.min_items.unwrap_or_else(|| unwrapped.len());
                                 // set items to optional
-                                for i in min_items..unwrapped.len() {
-                                    unwrapped[i].nullable = true;
+                                for item in unwrapped.iter_mut().skip(min_items) {
+                                    item.nullable = true;
                                 }
                                 match &self.array.additional_items {
                                     Some(AdditionalProperties::Object(tag)) => {

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -672,7 +672,7 @@ mod tests {
         "type": {
             "array": {
                 "items": {
-                    "name": "items",
+                    "name": "list",
                     "nullable": false,
                     "type": {"atom": "integer"}
                 }}}});
@@ -897,15 +897,15 @@ mod tests {
         "nullable": false,
         "type": {"array": {"items": {
             "nullable": false,
-            "name": "items",
+            "name": "list",
             "type": {"array": {"items": {
                 "nullable": false,
-                "name": "items",
-                "namespace": ".items",
+                "name": "list",
+                "namespace": ".list",
                 "type": {"tuple": {"items": [
                     {
                         "name": "f0_",
-                        "namespace": ".items.items",
+                        "namespace": ".list.list",
                         "type": {"atom": "integer"},
                         "nullable": false
                     }]}}}}}}}}});

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -877,4 +877,38 @@ mod tests {
         });
         assert_eq!(expect, translate_tuple(data))
     }
+
+    #[test]
+    fn test_into_ast_array_of_array_of_tuples() {
+        let data = json!({
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": [
+                        {"type": "integer"}
+                    ],
+                    "additionalItems": false
+                }
+            }
+        });
+        let expect = json!({
+        "nullable": false,
+        "type": {"array": {"items": {
+            "nullable": false,
+            "name": "items",
+            "type": {"array": {"items": {
+                "nullable": false,
+                "name": "items",
+                "namespace": ".items",
+                "type": {"tuple": {"items": [
+                    {
+                        "name": "f0_",
+                        "namespace": ".items.items",
+                        "type": {"atom": "integer"},
+                        "nullable": false
+                    }]}}}}}}}}});
+        assert_eq!(expect, translate_tuple(data))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate maplit;
 
 mod ast;
 mod avro;

--- a/tests/force_nullable.rs
+++ b/tests/force_nullable.rs
@@ -209,7 +209,7 @@ fn test_avro_force_nullable() {
                                             ]
                                         }
                                     ],
-                                    "name": "items",
+                                    "name": "list",
                                     "namespace": "root.array",
                                     "type": "record"
                                 }

--- a/tests/resources/translate/array.json
+++ b/tests/resources/translate/array.json
@@ -112,20 +112,26 @@
                   {
                     "name": "list",
                     "type": {
-                      "fields": [
-                        {
-                          "name": "list",
-                          "type": {
-                            "items": {
-                              "type": "long"
-                            },
-                            "type": "array"
+                      "items": {
+                        "fields": [
+                          {
+                            "name": "list",
+                            "type": {
+                              "items": {
+                                "items": {
+                                  "type": "long"
+                                },
+                                "type": "array"
+                              },
+                              "type": "array"
+                            }
                           }
-                        }
-                      ],
-                      "name": "list",
-                      "namespace": "root.array",
-                      "type": "record"
+                        ],
+                        "name": "list",
+                        "namespace": "root.array",
+                        "type": "record"
+                      },
+                      "type": "array"
                     }
                   }
                 ],

--- a/tests/resources/translate/array.json
+++ b/tests/resources/translate/array.json
@@ -114,26 +114,20 @@
                       "name": "list",
                       "type": {
                         "items": {
-                          "items": {
-                            "fields": [
-                              {
-                                "name": "list",
-                                "type": {
-                                  "items": {
-                                    "items": {
-                                      "type": "long"
-                                    },
-                                    "type": "array"
-                                  },
-                                  "type": "array"
-                                }
+                          "fields": [
+                            {
+                              "name": "list",
+                              "type": {
+                                "items": {
+                                  "type": "long"
+                                },
+                                "type": "array"
                               }
-                            ],
-                            "name": "list",
-                            "namespace": "root.array",
-                            "type": "record"
-                          },
-                          "type": "array"
+                            }
+                          ],
+                          "name": "list",
+                          "namespace": "root.array",
+                          "type": "record"
                         },
                         "type": "array"
                       }

--- a/tests/resources/translate/array.json
+++ b/tests/resources/translate/array.json
@@ -98,6 +98,83 @@
           "type": "array"
         }
       }
+    },
+    {
+      "name": "test_array_of_array",
+      "compatible": true,
+      "test": {
+        "avro": {
+          "fields": [
+            {
+              "fields": [
+                {
+                  "name": "items",
+                  "type": {
+                    "fields": [
+                      {
+                        "name": "items",
+                        "type": {
+                          "items": {
+                            "type": "long"
+                          },
+                          "type": "array"
+                        }
+                      }
+                    ],
+                    "name": "items",
+                    "type": "record"
+                  }
+                }
+              ],
+              "name": "array",
+              "type": "record"
+            }
+          ],
+          "name": "root",
+          "type": "record"
+        },
+        "bigquery": [
+          {
+            "fields": [
+              {
+                "fields": [
+                  {
+                    "mode": "REPEATED",
+                    "name": "items",
+                    "type": "INT64"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "items",
+                "type": "RECORD"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "array",
+            "type": "RECORD"
+          }
+        ],
+        "json": {
+          "properties": {
+            "array": {
+              "items": {
+                "items": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "array"
+          ],
+          "type": "object"
+        }
+      }
     }
   ]
 }

--- a/tests/resources/translate/array.json
+++ b/tests/resources/translate/array.json
@@ -58,7 +58,7 @@
                 ]
               }
             ],
-            "name": "items",
+            "name": "list",
             "namespace": "root",
             "type": "record"
           },
@@ -106,28 +106,33 @@
         "avro": {
           "fields": [
             {
-              "fields": [
-                {
-                  "name": "items",
-                  "type": {
-                    "fields": [
-                      {
-                        "name": "items",
-                        "type": {
-                          "items": {
-                            "type": "long"
-                          },
-                          "type": "array"
-                        }
-                      }
-                    ],
-                    "name": "items",
-                    "type": "record"
-                  }
-                }
-              ],
               "name": "array",
-              "type": "record"
+              "type": {
+                "fields": [
+                  {
+                    "name": "list",
+                    "type": {
+                      "fields": [
+                        {
+                          "name": "list",
+                          "type": {
+                            "items": {
+                              "type": "long"
+                            },
+                            "type": "array"
+                          }
+                        }
+                      ],
+                      "name": "list",
+                      "namespace": "root.array",
+                      "type": "record"
+                    }
+                  }
+                ],
+                "name": "array",
+                "namespace": "root",
+                "type": "record"
+              }
             }
           ],
           "name": "root",
@@ -140,12 +145,12 @@
                 "fields": [
                   {
                     "mode": "REPEATED",
-                    "name": "items",
+                    "name": "list",
                     "type": "INT64"
                   }
                 ],
                 "mode": "REPEATED",
-                "name": "items",
+                "name": "list",
                 "type": "RECORD"
               }
             ],

--- a/tests/resources/translate/array.json
+++ b/tests/resources/translate/array.json
@@ -108,36 +108,42 @@
             {
               "name": "array",
               "type": {
-                "fields": [
-                  {
-                    "name": "list",
-                    "type": {
-                      "items": {
-                        "fields": [
-                          {
+                "items": {
+                  "fields": [
+                    {
+                      "name": "list",
+                      "type": {
+                        "items": {
+                          "items": {
+                            "fields": [
+                              {
+                                "name": "list",
+                                "type": {
+                                  "items": {
+                                    "items": {
+                                      "type": "long"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "type": "array"
+                                }
+                              }
+                            ],
                             "name": "list",
-                            "type": {
-                              "items": {
-                                "items": {
-                                  "type": "long"
-                                },
-                                "type": "array"
-                              },
-                              "type": "array"
-                            }
-                          }
-                        ],
-                        "name": "list",
-                        "namespace": "root.array",
-                        "type": "record"
-                      },
-                      "type": "array"
+                            "namespace": "root.array",
+                            "type": "record"
+                          },
+                          "type": "array"
+                        },
+                        "type": "array"
+                      }
                     }
-                  }
-                ],
-                "name": "array",
-                "namespace": "root",
-                "type": "record"
+                  ],
+                  "name": "array",
+                  "namespace": "root",
+                  "type": "record"
+                },
+                "type": "array"
               }
             }
           ],

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -98,6 +98,73 @@ fn avro_test_array_with_complex() {
 }
 
 #[test]
+fn avro_test_array_of_array() {
+    let input_data = r#"
+    {
+      "properties": {
+        "array": {
+          "items": {
+            "items": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "array"
+      ],
+      "type": "object"
+    }
+    "#;
+    let expected_data = r#"
+    {
+      "fields": [
+        {
+          "fields": [
+            {
+              "name": "items",
+              "type": {
+                "fields": [
+                  {
+                    "name": "items",
+                    "type": {
+                      "items": {
+                        "type": "long"
+                      },
+                      "type": "array"
+                    }
+                  }
+                ],
+                "name": "items",
+                "type": "record"
+              }
+            }
+          ],
+          "name": "array",
+          "type": "record"
+        }
+      ],
+      "name": "root",
+      "type": "record"
+    }
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
+}
+
+#[test]
 fn avro_test_atomic() {
     let input_data = r#"
     {

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -127,36 +127,42 @@ fn avro_test_array_of_array() {
         {
           "name": "array",
           "type": {
-            "fields": [
-              {
-                "name": "list",
-                "type": {
-                  "items": {
-                    "fields": [
-                      {
+            "items": {
+              "fields": [
+                {
+                  "name": "list",
+                  "type": {
+                    "items": {
+                      "items": {
+                        "fields": [
+                          {
+                            "name": "list",
+                            "type": {
+                              "items": {
+                                "items": {
+                                  "type": "long"
+                                },
+                                "type": "array"
+                              },
+                              "type": "array"
+                            }
+                          }
+                        ],
                         "name": "list",
-                        "type": {
-                          "items": {
-                            "items": {
-                              "type": "long"
-                            },
-                            "type": "array"
-                          },
-                          "type": "array"
-                        }
-                      }
-                    ],
-                    "name": "list",
-                    "namespace": "root.array",
-                    "type": "record"
-                  },
-                  "type": "array"
+                        "namespace": "root.array",
+                        "type": "record"
+                      },
+                      "type": "array"
+                    },
+                    "type": "array"
+                  }
                 }
-              }
-            ],
-            "name": "array",
-            "namespace": "root",
-            "type": "record"
+              ],
+              "name": "array",
+              "namespace": "root",
+              "type": "record"
+            },
+            "type": "array"
           }
         }
       ],

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -131,20 +131,26 @@ fn avro_test_array_of_array() {
               {
                 "name": "list",
                 "type": {
-                  "fields": [
-                    {
-                      "name": "list",
-                      "type": {
-                        "items": {
-                          "type": "long"
-                        },
-                        "type": "array"
+                  "items": {
+                    "fields": [
+                      {
+                        "name": "list",
+                        "type": {
+                          "items": {
+                            "items": {
+                              "type": "long"
+                            },
+                            "type": "array"
+                          },
+                          "type": "array"
+                        }
                       }
-                    }
-                  ],
-                  "name": "list",
-                  "namespace": "root.array",
-                  "type": "record"
+                    ],
+                    "name": "list",
+                    "namespace": "root.array",
+                    "type": "record"
+                  },
+                  "type": "array"
                 }
               }
             ],

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -79,7 +79,7 @@ fn avro_test_array_with_complex() {
             ]
           }
         ],
-        "name": "items",
+        "name": "list",
         "namespace": "root",
         "type": "record"
       },
@@ -125,28 +125,33 @@ fn avro_test_array_of_array() {
     {
       "fields": [
         {
-          "fields": [
-            {
-              "name": "items",
-              "type": {
-                "fields": [
-                  {
-                    "name": "items",
-                    "type": {
-                      "items": {
-                        "type": "long"
-                      },
-                      "type": "array"
-                    }
-                  }
-                ],
-                "name": "items",
-                "type": "record"
-              }
-            }
-          ],
           "name": "array",
-          "type": "record"
+          "type": {
+            "fields": [
+              {
+                "name": "list",
+                "type": {
+                  "fields": [
+                    {
+                      "name": "list",
+                      "type": {
+                        "items": {
+                          "type": "long"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  ],
+                  "name": "list",
+                  "namespace": "root.array",
+                  "type": "record"
+                }
+              }
+            ],
+            "name": "array",
+            "namespace": "root",
+            "type": "record"
+          }
         }
       ],
       "name": "root",

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -133,26 +133,20 @@ fn avro_test_array_of_array() {
                   "name": "list",
                   "type": {
                     "items": {
-                      "items": {
-                        "fields": [
-                          {
-                            "name": "list",
-                            "type": {
-                              "items": {
-                                "items": {
-                                  "type": "long"
-                                },
-                                "type": "array"
-                              },
-                              "type": "array"
-                            }
+                      "fields": [
+                        {
+                          "name": "list",
+                          "type": {
+                            "items": {
+                              "type": "long"
+                            },
+                            "type": "array"
                           }
-                        ],
-                        "name": "list",
-                        "namespace": "root.array",
-                        "type": "record"
-                      },
-                      "type": "array"
+                        }
+                      ],
+                      "name": "list",
+                      "namespace": "root.array",
+                      "type": "record"
                     },
                     "type": "array"
                   }

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -84,6 +84,64 @@ fn bigquery_test_array_with_complex() {
 }
 
 #[test]
+fn bigquery_test_array_of_array() {
+    let input_data = r#"
+    {
+      "properties": {
+        "array": {
+          "items": {
+            "items": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "array"
+      ],
+      "type": "object"
+    }
+    "#;
+    let expected_data = r#"
+    [
+      {
+        "fields": [
+          {
+            "fields": [
+              {
+                "mode": "REPEATED",
+                "name": "items",
+                "type": "INT64"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "items",
+            "type": "RECORD"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "array",
+        "type": "RECORD"
+      }
+    ]
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_bigquery(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_bigquery(&input, context);
+}
+
+#[test]
 fn bigquery_test_atomic() {
     let input_data = r#"
     {

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -115,12 +115,12 @@ fn bigquery_test_array_of_array() {
             "fields": [
               {
                 "mode": "REPEATED",
-                "name": "items",
+                "name": "list",
                 "type": "INT64"
               }
             ],
             "mode": "REPEATED",
-            "name": "items",
+            "name": "list",
             "type": "RECORD"
           }
         ],


### PR DESCRIPTION
Nested lists are not handled correctly.

```bash
$ echo '{
            "type": "array",
            "items": {
                "type": "array",
                "items": {
                    "type": "array",
                    "items": [
                        {"type": "integer"}
                    ],
                    "additionalItems": false
                }
            }
        }' | jsonschema-transpiler --type bigquery --tuple-struct
```
results in 

```json
[
  {
    "fields": [
      {
        "mode": "REQUIRED",
        "name": "f0_",
        "type": "INT64"
      }
    ],
    "mode": "REPEATED",
    "name": "root",
    "type": "RECORD"
  }
]
```

This PR fixes this so there is an intermediate layer that can be used for unnesting.

```json
[
  {
    "fields": [
      {
        "fields": [
          {
            "mode": "REQUIRED",
            "name": "f0_",
            "type": "INT64"
          }
        ],
        "mode": "REPEATED",
        "name": "list",
        "type": "RECORD"
      }
    ],
    "mode": "REPEATED",
    "name": "root",
    "type": "RECORD"
  }
]
```

See this gist for the result of the verification script: https://gist.github.com/acmiyaguchi/619b113f0b536480919ecf90a4028036. This lines up with the experience with the third party modules and untrusted modules pings, which are likely the only pings with nested arrays.
