### PR TITLE
Propagate "description" from json schema to BigQuery schema

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -72,6 +72,7 @@ impl Map {
                 nullable: false,
                 is_root: false,
                 description: None,
+                title: None,
             }),
             value: Box::new(value),
         }
@@ -108,6 +109,7 @@ impl Union {
                 is_root: false,
                 data_type: self.items[0].data_type.clone(),
                 description: None,
+                title: None,
             };
         }
 
@@ -233,6 +235,7 @@ impl Union {
             data_type,
             is_root: false,
             description: None,
+            title: None,
         };
         tag.infer_nullability(false);
         tag
@@ -279,6 +282,9 @@ pub struct Tag {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 impl Tag {
@@ -287,6 +293,7 @@ impl Tag {
         name: Option<String>,
         nullable: bool,
         description: Option<String>,
+        title: Option<String>,
     ) -> Self {
         Tag {
             data_type,
@@ -295,6 +302,7 @@ impl Tag {
             nullable,
             is_root: false,
             description,
+            title,
         }
     }
 
@@ -924,16 +932,21 @@ mod tests {
             Tag::new(
                 Type::Map(Map::new(
                     None,
-                    Tag::new(Type::Atom(Atom::Integer), None, false, None),
+                    Tag::new(Type::Atom(Atom::Integer), None, false, None, None),
                 )),
                 None,
                 false,
                 None,
+                None,
             ),
             Tag::new(
-                Type::Map(Map::new(None, Tag::new(Type::Null, None, false, None))),
+                Type::Map(Map::new(
+                    None,
+                    Tag::new(Type::Null, None, false, None, None),
+                )),
                 None,
                 false,
+                None,
                 None,
             ),
         ]));

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -53,7 +53,7 @@ pub struct Tuple {
 impl Tuple {
     pub fn new(items: Vec<Tag>) -> Self {
         Tuple {
-            items: items.clone(),
+            items,
         }
     }
 }
@@ -95,7 +95,7 @@ impl Union {
     /// type is found, it will be converted into a JSON type. Because of the ambiguity
     /// around finding structure in a JSON blob, the union of any type with JSON will
     /// be consumed by the JSON type. In a similar fashion, a table schema is determined
-    /// to be nullable or required via occurances of null types in unions.
+    /// to be nullable or required via occurrences of null types in unions.
     pub fn collapse(&self) -> Tag {
         let is_null = self.items.iter().any(Tag::is_null);
 

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -265,9 +265,12 @@ impl TranslateFrom<ast::Tag> for Type {
                     values: Box::new(data_type),
                 })),
                 // Err is only reachable when context.resolve_method is Drop
-                Err(_) => match context.allow_maps_without_value {
-                    true => return Err(fmt_reason("map value cannot be dropped in avro")),
-                    false => return Err(fmt_reason("untyped map value")),
+                Err(_) => {
+                    return if context.allow_maps_without_value {
+                        Err(fmt_reason("map value cannot be dropped in avro"))
+                    } else {
+                        Err(fmt_reason("untyped map value"))
+                    }
                 },
             },
             _ => handle_error("unknown type")?,

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -271,7 +271,7 @@ impl TranslateFrom<ast::Tag> for Type {
                     } else {
                         Err(fmt_reason("untyped map value"))
                     }
-                },
+                }
             },
             _ => handle_error("unknown type")?,
         };

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -155,10 +155,12 @@ impl TranslateFrom<ast::Tag> for Tag {
                 let key = Tag::translate_from(*map.key.clone(), context).unwrap();
                 let value = match Tag::translate_from(*map.value.clone(), context) {
                     Ok(tag) => Some(tag),
-                    // Err is only reachable when context.resolve_method is Drop
-                    Err(_) => match context.allow_maps_without_value {
-                        true => None,
-                        false => return Err(fmt_reason("untyped map value")),
+                    Err(_) => {
+                        if context.allow_maps_without_value {
+                            None
+                        } else {
+                            return Err(fmt_reason("untyped map value"))
+                        }
                     },
                 };
                 let fields: HashMap<String, Box<Tag>> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod traits;
 use serde_json::{json, Value};
 use traits::TranslateFrom;
 
-/// The error resoluton method in the [`TranslateFrom`] and [`TranslateInto`]
+/// The error resolution method in the [`TranslateFrom`] and [`TranslateInto`]
 /// interfaces when converting between schema formats.
 ///
 /// The `Cast` method will represent under-specified (e.g. empty objects) and

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
         )
         .get_matches();
 
-    let reader: Box<io::Read> = match matches.value_of("file") {
+    let reader: Box<dyn io::Read> = match matches.value_of("file") {
         Some(path) if path == "-" => Box::new(io::stdin()),
         Some(path) => {
             let file = File::open(path).unwrap();

--- a/tests/resources/translate/atomic.json
+++ b/tests/resources/translate/atomic.json
@@ -146,6 +146,70 @@
           "type": "string"
         }
       }
+    },
+    {
+      "name": "test_atomic_with_description",
+      "compatible": true,
+      "test": {
+        "avro": {
+          "type": "long"
+        },
+        "bigquery": [
+          {
+            "description": "test description",
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "INT64"
+          }
+        ],
+        "json": {
+          "description": "test description",
+          "type": "integer"
+        }
+      }
+    },
+    {
+      "name": "test_atomic_with_description_and_title",
+      "compatible": true,
+      "test": {
+        "avro": {
+          "type": "long"
+        },
+        "bigquery": [
+          {
+            "description": "test title - test description",
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "INT64"
+          }
+        ],
+        "json": {
+          "description": "test description",
+          "title": "test title",
+          "type": "integer"
+        }
+      }
+    },
+    {
+      "name": "test_atomic_with_title",
+      "compatible": true,
+      "test": {
+        "avro": {
+          "type": "long"
+        },
+        "bigquery": [
+          {
+            "description": "test title",
+            "mode": "REQUIRED",
+            "name": "root",
+            "type": "INT64"
+          }
+        ],
+        "json": {
+          "title": "test title",
+          "type": "integer"
+        }
+      }
     }
   ]
 }

--- a/tests/resources/translate/map.json
+++ b/tests/resources/translate/map.json
@@ -85,6 +85,7 @@
         },
         "bigquery": [
           {
+            "description": "root description",
             "fields": [
               {
                 "mode": "REQUIRED",
@@ -92,8 +93,10 @@
                 "type": "STRING"
               },
               {
+                "description": "object description",
                 "fields": [
                   {
+                    "description": "field description",
                     "mode": "NULLABLE",
                     "name": "field_1",
                     "type": "STRING"
@@ -116,8 +119,10 @@
         ],
         "json": {
           "additionalProperties": {
+            "description": "object description",
             "properties": {
               "field_1": {
+                "description": "field description",
                 "type": "string"
               },
               "field_2": {
@@ -126,6 +131,7 @@
             },
             "type": "object"
           },
+          "description": "root description",
           "type": "object"
         }
       }

--- a/tests/resources/translate/object.json
+++ b/tests/resources/translate/object.json
@@ -318,6 +318,7 @@
           {
             "fields": [
               {
+                "description": "field description",
                 "mode": "NULLABLE",
                 "name": "field_1",
                 "type": "STRING"
@@ -338,6 +339,7 @@
             "namespace_1": {
               "properties": {
                 "field_1": {
+                  "description": "field description",
                   "type": "string"
                 },
                 "field_2": {

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -338,6 +338,79 @@ fn avro_test_bytes_format() {
 }
 
 #[test]
+fn avro_test_atomic_with_description() {
+    let input_data = r#"
+    {
+      "description": "test description",
+      "type": "integer"
+    }
+    "#;
+    let expected_data = r#"
+    {
+      "type": "long"
+    }
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
+}
+
+#[test]
+fn avro_test_atomic_with_description_and_title() {
+    let input_data = r#"
+    {
+      "description": "test description",
+      "title": "test title",
+      "type": "integer"
+    }
+    "#;
+    let expected_data = r#"
+    {
+      "type": "long"
+    }
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
+}
+
+#[test]
+fn avro_test_atomic_with_title() {
+    let input_data = r#"
+    {
+      "title": "test title",
+      "type": "integer"
+    }
+    "#;
+    let expected_data = r#"
+    {
+      "type": "long"
+    }
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_avro(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
+}
+
+#[test]
 fn avro_test_map_with_atomics() {
     let input_data = r#"
     {
@@ -371,8 +444,10 @@ fn avro_test_map_with_complex() {
     let input_data = r#"
     {
       "additionalProperties": {
+        "description": "object description",
         "properties": {
           "field_1": {
+            "description": "field description",
             "type": "string"
           },
           "field_2": {
@@ -381,6 +456,7 @@ fn avro_test_map_with_complex() {
         },
         "type": "object"
       },
+      "description": "root description",
       "type": "object"
     }
     "#;
@@ -803,6 +879,7 @@ fn avro_test_object_with_complex() {
         "namespace_1": {
           "properties": {
             "field_1": {
+              "description": "field description",
               "type": "string"
             },
             "field_2": {

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -318,6 +318,94 @@ fn bigquery_test_bytes_format() {
 }
 
 #[test]
+fn bigquery_test_atomic_with_description() {
+    let input_data = r#"
+    {
+      "description": "test description",
+      "type": "integer"
+    }
+    "#;
+    let expected_data = r#"
+    [
+      {
+        "description": "test description",
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "INT64"
+      }
+    ]
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_bigquery(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_bigquery(&input, context);
+}
+
+#[test]
+fn bigquery_test_atomic_with_description_and_title() {
+    let input_data = r#"
+    {
+      "description": "test description",
+      "title": "test title",
+      "type": "integer"
+    }
+    "#;
+    let expected_data = r#"
+    [
+      {
+        "description": "test title - test description",
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "INT64"
+      }
+    ]
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_bigquery(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_bigquery(&input, context);
+}
+
+#[test]
+fn bigquery_test_atomic_with_title() {
+    let input_data = r#"
+    {
+      "title": "test title",
+      "type": "integer"
+    }
+    "#;
+    let expected_data = r#"
+    [
+      {
+        "description": "test title",
+        "mode": "REQUIRED",
+        "name": "root",
+        "type": "INT64"
+      }
+    ]
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_bigquery(&input, context));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_bigquery(&input, context);
+}
+
+#[test]
 fn bigquery_test_map_with_atomics() {
     let input_data = r#"
     {
@@ -364,8 +452,10 @@ fn bigquery_test_map_with_complex() {
     let input_data = r#"
     {
       "additionalProperties": {
+        "description": "object description",
         "properties": {
           "field_1": {
+            "description": "field description",
             "type": "string"
           },
           "field_2": {
@@ -374,12 +464,14 @@ fn bigquery_test_map_with_complex() {
         },
         "type": "object"
       },
+      "description": "root description",
       "type": "object"
     }
     "#;
     let expected_data = r#"
     [
       {
+        "description": "root description",
         "fields": [
           {
             "mode": "REQUIRED",
@@ -387,8 +479,10 @@ fn bigquery_test_map_with_complex() {
             "type": "STRING"
           },
           {
+            "description": "object description",
             "fields": [
               {
+                "description": "field description",
                 "mode": "NULLABLE",
                 "name": "field_1",
                 "type": "STRING"
@@ -781,6 +875,7 @@ fn bigquery_test_object_with_complex() {
         "namespace_1": {
           "properties": {
             "field_1": {
+              "description": "field description",
               "type": "string"
             },
             "field_2": {
@@ -798,6 +893,7 @@ fn bigquery_test_object_with_complex() {
       {
         "fields": [
           {
+            "description": "field description",
             "mode": "NULLABLE",
             "name": "field_1",
             "type": "STRING"


### PR DESCRIPTION
This addresses https://github.com/mozilla/jsonschema-transpiler/issues/58.

I also fixed some formatting and clippy issues in the process. For now I extended existing tests but I could also create separate test cases for testing the description propagation if wanted.