### PR TITLE
Updated command examples to represent current output

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ $ echo $schema | jsonschema-transpiler --type avro
 {
   "fields": [
     {
+      "default": null,
       "name": "foo",
       "type": [
         {
@@ -91,17 +92,13 @@ $ echo $schema | jsonschema-transpiler --type avro
 }
 
 $ echo $schema | jsonschema-transpiler --type bigquery
-{
-  "fields": [
-    {
-      "mode": "NULLABLE",
-      "name": "foo",
-      "type": "BOOL"
-    }
-  ],
-  "mode": "REQUIRED",
-  "type": "RECORD"
-}
+[
+  {
+    "mode": "NULLABLE",
+    "name": "foo",
+    "type": "BOOL"
+  }
+]
 ```
 
 ## Building


### PR DESCRIPTION
Updated command examples to represent current output. I've run the example commands and I got a slightly different output for the `jsonschema-transpiler` examples. This proposed updating the README to reflect that.

Package version:
```bash
$ cargo install --list
jsonschema-transpiler v1.10.0:
    jsonschema-transpiler
```

Below is the output I get when running the examples:

```bash
echo $schema | jq
{
  "type": "object",
  "properties": {
    "foo": {
      "type": "boolean"
    }
  }
}
```

```bash
echo $schema | jsonschema-transpiler --type avro
{
  "fields": [
    {
      "default": null,
      "name": "foo",
      "type": [
        {
          "type": "null"
        },
        {
          "type": "boolean"
        }
      ]
    }
  ],
  "name": "root",
  "type": "record"
}
```

```bash
$ echo $schema | jsonschema-transpiler --type bigquery
[
  {
    "mode": "NULLABLE",
    "name": "foo",
    "type": "BOOL"
  }
]
```