### PR TITLE
[DENG-10731] Add descriptions to arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 name = "jsonschema-transpiler"
 readme = "README.md"
 repository = "https://github.com/mozilla/jsonschema-transpiler"
-version = "2.0.0"
+version = "2.0.1"
 
 [lib]
 name = "jst"

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -598,6 +598,7 @@ mod tests {
     #[test]
     fn test_from_ast_array() {
         let data = json!({
+        "description": "foo",
         "type": {
             "array": {
                 "items": {
@@ -606,6 +607,7 @@ mod tests {
         let expect = json!({
             "type": "INT64",
             "mode": "REPEATED",
+            "description": "foo",
         });
         assert_eq!(expect, transform_tag(data));
     }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -369,7 +369,7 @@ impl Tag {
                             }
                         }
                     };
-                    ast::Tag::new(data_type, None, false, None, None)
+                    ast::Tag::new(data_type, None, false, description, title)
                 } else {
                     return Err("array missing item");
                 }

--- a/tests/resources/translate/array.json
+++ b/tests/resources/translate/array.json
@@ -27,6 +27,33 @@
       }
     },
     {
+      "name": "test_array_with_atomic_with_description",
+      "compatible": true,
+      "test": {
+        "avro": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "bigquery": [
+          {
+            "description": "foo",
+            "mode": "REPEATED",
+            "name": "root",
+            "type": "STRING"
+          }
+        ],
+        "json": {
+          "description": "foo",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      }
+    },
+    {
       "name": "test_array_with_complex",
       "compatible": true,
       "test": {

--- a/tests/transpile_avro.rs
+++ b/tests/transpile_avro.rs
@@ -38,6 +38,41 @@ fn avro_test_array_with_atomics() {
 }
 
 #[test]
+fn avro_test_array_with_atomic_with_description() {
+    let input_data = r#"
+    {
+      "description": "foo",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+    "#;
+    let expected_data = r#"
+    {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+    "#;
+    let mut context = Context {
+        ..Default::default()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    if expected.is_null() {
+        // No expected data = no avro support
+        return;
+    }
+
+    assert_eq!(expected, convert_avro(&input, context.clone()));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_avro(&input, context);
+}
+
+#[test]
 fn avro_test_array_with_complex() {
     let input_data = r#"
     {

--- a/tests/transpile_bigquery.rs
+++ b/tests/transpile_bigquery.rs
@@ -40,6 +40,44 @@ fn bigquery_test_array_with_atomics() {
 }
 
 #[test]
+fn bigquery_test_array_with_atomic_with_description() {
+    let input_data = r#"
+    {
+      "description": "foo",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+    "#;
+    let expected_data = r#"
+    [
+      {
+        "description": "foo",
+        "mode": "REPEATED",
+        "name": "root",
+        "type": "STRING"
+      }
+    ]
+    "#;
+    let context_data = r#"
+    null
+    "#;
+    let context: Value = serde_json::from_str(context_data).unwrap();
+    let mut context: Context = if context.is_null() {
+        Default::default()
+    } else {
+        serde_json::from_value(context).unwrap()
+    };
+    let input: Value = serde_json::from_str(input_data).unwrap();
+    let expected: Value = serde_json::from_str(expected_data).unwrap();
+    assert_eq!(expected, convert_bigquery(&input, context.clone()));
+
+    context.resolve_method = ResolveMethod::Panic;
+    convert_bigquery(&input, context);
+}
+
+#[test]
 fn bigquery_test_array_with_complex() {
     let input_data = r#"
     {


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-10731

Only string_list metrics don't have descriptions in bigquery.  Descriptions were originally added in https://github.com/mozilla/jsonschema-transpiler/pull/93 but arrays had it set to none.  I'm not sure if this was intentional but I don't see any side effects of doing this.

Test changes for org-mozilla-fenix-nightly: https://github.com/mozilla-services/mozilla-pipeline-schemas/compare/generated-schemas...benwu/test-string-list-desc

Tested with
```sh
# in jsonschema-transpiler
cargo install --path .

# in mozilla-schema-generator
mozilla-schema-generator generate-glean-pings --out-dir schema_out/ --pretty  --repo org-mozilla-fenix-nightly
for schema in $(find schema_out -name "*.schema.json" -type f); do     
    bin/metadata_merge metadata/ "$schema"
done 
find schema_out -type f -name "*.schema.json" | while read -r fname; do
    bq_out=${fname/schema.json/bq}        
    mkdir -p "$(dirname "$bq_out")"
    jsonschema-transpiler --resolve drop --type bigquery --normalize-case --force-nullable --tuple-struct "$fname" > "$bq_out"
done
mozilla-schema-generator generate-glean-pings --out-dir schema_out/ --pretty --generic-schema --repo org-mozilla-fenix-nightly
```